### PR TITLE
[Feat] 과제 A - 강의 등록 및 수강신청 관리를 위한 Entity 클래스 구현

### DIFF
--- a/src/main/java/com/example/assignment/AssignmentApplication.java
+++ b/src/main/java/com/example/assignment/AssignmentApplication.java
@@ -2,7 +2,9 @@ package com.example.assignment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class AssignmentApplication {
 

--- a/src/main/java/com/example/assignment/domain/dto/PageResponse.java
+++ b/src/main/java/com/example/assignment/domain/dto/PageResponse.java
@@ -1,0 +1,52 @@
+package com.example.assignment.domain.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+
+@Getter
+@AllArgsConstructor
+public class PageResponse<T> {
+
+  private int pageNumber;  // 현재 페이지 번호
+  private int totalPage;   // 총 페이지 수
+  private Long totalData;  // 전체 데이터 개수
+  private List<T> dataList; // 현재 페이지의 데이터 리스트
+
+  /**
+   * 리스트 데이터를 페이징 처리하여 PageResponse로 변환
+   *
+   * @param list       페이징할 리스트 데이터
+   * @param pageNumber 요청한 페이지 번호
+   * @return PageResponse 형태의 페이징 결과
+   */
+  public static <T> PageResponse<T> pagination(List<T> list, int pageNumber) {
+    int pageSize = 10;  // 페이지 크기 설정
+    Pageable pageable = PageRequest.of(pageNumber - 1, pageSize);
+    int start = (int) pageable.getOffset();
+
+    // start 인덱스가 데이터 리스트 크기를 초과하면 빈 페이지 반환
+    if (start >= list.size()) {
+      return new PageResponse<>(pageNumber, 0, 0L, List.of());
+    }
+
+    int end = Math.min(start + pageSize, list.size());
+    List<T> pagedList = list.subList(start, end);
+
+    // 페이징 객체 생성
+    Page<T> page = new PageImpl<>(pagedList, pageable, list.size());
+
+    // PageResponse 변환 및 반환
+    return new PageResponse<>(
+        page.getNumber() + 1,   // 페이지 번호는 1부터 시작
+        page.getTotalPages(),   // 전체 페이지 수
+        page.getTotalElements(),// 전체 데이터 개수
+        page.getContent()       // 현재 페이지 데이터 리스트
+    );
+  }
+}

--- a/src/main/java/com/example/assignment/domain/dto/ResultResponse.java
+++ b/src/main/java/com/example/assignment/domain/dto/ResultResponse.java
@@ -1,0 +1,41 @@
+package com.example.assignment.domain.dto;
+
+import com.example.assignment.domain.type.FailedType;
+import com.example.assignment.domain.type.SuccessType;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+public class ResultResponse {
+
+  private final Integer code;
+  private final HttpStatus status;
+  private final String message;
+  private final Object data;
+
+  // 요청 응답 시 반환할 데이터가 존재 할 경우
+  public ResultResponse(SuccessType successResultCode, Object data) {
+    this.code = successResultCode.getStatus().value();
+    this.status = successResultCode.getStatus();
+    this.message = successResultCode.getMessage();
+    this.data = data;
+  }
+
+  public ResultResponse(FailedType failedResultCode,  Object data) {
+    this.code = failedResultCode.getStatus().value();
+    this.status = failedResultCode.getStatus();
+    this.message = failedResultCode.getMessage();
+    this.data = data;
+  }
+
+  // 요청 응답 시 반환할 데이터가 존재하지 않을 경우
+  public static ResultResponse of(SuccessType successResultCode) {
+    return new ResultResponse(successResultCode, null);
+  }
+
+  public static ResultResponse of(FailedType failedResultCode) {
+    return new ResultResponse(failedResultCode, null);
+  }
+
+}

--- a/src/main/java/com/example/assignment/domain/entity/BaseEntity.java
+++ b/src/main/java/com/example/assignment/domain/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.example.assignment.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -1,0 +1,40 @@
+package com.example.assignment.domain.entity;
+
+import com.example.assignment.domain.type.CourseStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Course extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long courseId;
+
+  private String title;
+
+  private String description;
+
+  private int personnel;
+
+  private LocalDate startPeriodAt;
+
+  private LocalDate endPeriodAt;
+
+  @Enumerated(EnumType.STRING)
+  private CourseStatus courseStatus;
+
+}

--- a/src/main/java/com/example/assignment/domain/entity/Enrollment.java
+++ b/src/main/java/com/example/assignment/domain/entity/Enrollment.java
@@ -1,0 +1,40 @@
+package com.example.assignment.domain.entity;
+
+import com.example.assignment.domain.type.EnrollmentStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Enrollment extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long enrollmentId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "course_id")
+  private Course courseId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_Id")
+  private User userId;
+
+  @Enumerated(EnumType.STRING)
+  private EnrollmentStatus enrollmentStatus;
+
+}

--- a/src/main/java/com/example/assignment/domain/entity/User.java
+++ b/src/main/java/com/example/assignment/domain/entity/User.java
@@ -1,0 +1,30 @@
+package com.example.assignment.domain.entity;
+
+import com.example.assignment.domain.type.UserRole;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long userId;
+
+  private String name;
+
+  @Enumerated(EnumType.STRING)
+  private UserRole userRole;
+}

--- a/src/main/java/com/example/assignment/domain/type/CourseStatus.java
+++ b/src/main/java/com/example/assignment/domain/type/CourseStatus.java
@@ -1,0 +1,14 @@
+package com.example.assignment.domain.type;
+
+import lombok.Getter;
+
+@Getter
+public enum CourseStatus {
+  DRAFT("초안"), OPEN("모집중"), CLOSED("모집 마감");
+
+  private final String value;
+
+  CourseStatus(String value) {
+    this.value = value;
+  }
+}

--- a/src/main/java/com/example/assignment/domain/type/EnrollmentStatus.java
+++ b/src/main/java/com/example/assignment/domain/type/EnrollmentStatus.java
@@ -1,0 +1,17 @@
+package com.example.assignment.domain.type;
+
+import lombok.Getter;
+
+@Getter
+public enum EnrollmentStatus {
+  PENDING("신청완료, 결제대기"),
+  CONFIRMED("결제완료, 수강 확정"),
+  CANCELLED("수강 취소");
+
+  private final String value;
+
+  EnrollmentStatus(String value) {
+    this.value = value;
+  }
+
+}

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -1,0 +1,14 @@
+package com.example.assignment.domain.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FailedType {
+  ;
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -1,0 +1,14 @@
+package com.example.assignment.domain.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessType {
+  ;
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/src/main/java/com/example/assignment/domain/type/UserRole.java
+++ b/src/main/java/com/example/assignment/domain/type/UserRole.java
@@ -1,0 +1,7 @@
+package com.example.assignment.domain.type;
+
+public enum UserRole {
+
+  CREATORS, STUDENT
+
+}

--- a/src/main/java/com/example/assignment/exception/GlobalException.java
+++ b/src/main/java/com/example/assignment/exception/GlobalException.java
@@ -1,0 +1,22 @@
+package com.example.assignment.exception;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import com.example.assignment.domain.type.FailedType;
+import lombok.Getter;
+
+@Getter
+public class GlobalException extends RuntimeException {
+
+  private final ResultResponse resultResponse;
+
+  public GlobalException(FailedType failedType) {
+    super("");
+    this.resultResponse = ResultResponse.of(failedType);
+  }
+
+  public GlobalException(ResultResponse resultResponse) {
+    super("");
+    this.resultResponse = resultResponse;
+  }
+
+}

--- a/src/main/java/com/example/assignment/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/assignment/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.example.assignment.exception;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+  @ExceptionHandler(GlobalException.class)
+  public ResponseEntity<ResultResponse> handleGlobalException(GlobalException ex) {
+    ResultResponse resultResponse = ex.getResultResponse();
+    return new ResponseEntity<>(resultResponse, resultResponse.getStatus());
+  }
+}


### PR DESCRIPTION
## 작업 내용
> 강의/수강신청 서비스를 개발하기에 위해, 도메인 전반에서 공통으로 사용할 기반 구조(엔티티, 공통 응답/예외 처리, 페이징) 구현

### 공통 Entity

- BaseEntity : @MappedSuperclass + JPA Auditing 기반으로 createdAt, updatedAt 자동 관리

### 도메인 Entity

- User : 사용자 정보 (테스트용, UserRole enum 포함)
```
-- 테이블 생성
   CREATE TABLE `user` (
    user_id    BIGINT       NOT NULL AUTO_INCREMENT,
    name       VARCHAR(255),
    user_role  VARCHAR(20),
    PRIMARY KEY (user_id)
);

-- 더미 데이터 삽입 (강사 5명, 학생 10명)
INSERT INTO `user` (name, user_role) VALUES
('강사1', 'CREATORS'),
('강사2', 'CREATORS'),
('강사3', 'CREATORS'),
('강사4', 'CREATORS'),
('강사5', 'CREATORS'),
('학생1', 'STUDENT'),
('학생2', 'STUDENT'),
('학생3', 'STUDENT'),
('학생4', 'STUDENT'),
('학생5', 'STUDENT'),
('학생6', 'STUDENT'),
('학생7', 'STUDENT'),
('학생8', 'STUDENT'),
('학생9', 'STUDENT'),
('학생10', 'STUDENT');
```
- Course : 강의 정보 (제목, 설명, 모집 인원, 모집 기간, 강의 상태)
- Enrollment : 수강신청 정보 (User, Course와 ManyToOne 연관관계, 지연 로딩 적용)

### Enum 타입 정의

- UserRole : CREATORS, STUDENT
- CourseStatus : DRAFT(초안), OPEN(모집중), CLOSED(모집 마감)
- EnrollmentStatus : PENDING(결제대기), CONFIRMED(수강 확정), CANCELLED(수강 취소)
- SuccessType, FailedType : 요청 성공/실패 응답 코드 (HttpStatus + message)

### 공통 응답 / 예외 처리

- ResultResponse : 일관된 응답 포맷 DTO (code, status, message, data)
- GlobalException : FailedType 또는 ResultResponse 기반으로 던지는 커스텀 예외
- GlobalExceptionHandler : @RestControllerAdvice로 GlobalException을 일괄 처리

### 페이징 처리

- PageResponse<T> : 제네릭 기반 페이징 응답 DTO (pageSize 10 고정, 1-base 페이지 번호 반환)