### PR TITLE
[Feat] 과제 A - 강의 등록 API 구현

### DIFF
--- a/src/main/java/com/example/assignment/controller/CourseController.java
+++ b/src/main/java/com/example/assignment/controller/CourseController.java
@@ -1,0 +1,28 @@
+package com.example.assignment.controller;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import com.example.assignment.domain.dto.request.CourseReq;
+import com.example.assignment.service.CourseService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/course")
+@RequiredArgsConstructor
+public class CourseController {
+
+  private final CourseService courseService;
+
+  @PostMapping
+  public ResponseEntity<ResultResponse> register(@RequestBody @Valid CourseReq courseReq) {
+
+    ResultResponse response = courseService.register(courseReq);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+}

--- a/src/main/java/com/example/assignment/domain/dto/request/CourseReq.java
+++ b/src/main/java/com/example/assignment/domain/dto/request/CourseReq.java
@@ -1,0 +1,45 @@
+package com.example.assignment.domain.dto.request;
+
+import com.example.assignment.domain.type.CourseStatus;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class CourseReq {
+
+  @NotNull(message = "강사ID를 입력해주세요.")
+  private Long userId;
+
+  @NotBlank(message = "제목을 입력해주세요.")
+  private String title;
+
+  @NotBlank(message = "설명을 입력해주세요")
+  private String description;
+
+  @NotNull(message = "최대 수강 인원을 입력해주세요.")
+  @Min(value = 5, message = "최대 수강 인원은 5명 이상이어야 합니다.")
+  private Long personnel;
+
+  @NotNull(message = "시작일을 입력해주세요")
+  @FutureOrPresent(message = "시작일은 오늘 또는 이후로 선택해주세요.")
+  private LocalDate startPeriodAt;
+
+  @NotNull(message = "종료일을 입력해주세요")
+  private LocalDate endPeriodAt;
+
+  @NotNull(message = "강의 상태를 입력해주세요")
+  private CourseStatus courseStatus;
+
+  @AssertTrue(message = "종료일은 시작일 이후여야 합니다.")
+  public boolean isValidPeriod() {
+    if (startPeriodAt == null || endPeriodAt == null) return true;
+    return endPeriodAt.isAfter(startPeriodAt);
+  }
+
+}

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -1,12 +1,16 @@
 package com.example.assignment.domain.entity;
 
+import com.example.assignment.domain.dto.request.CourseReq;
 import com.example.assignment.domain.type.CourseStatus;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,13 +32,29 @@ public class Course extends BaseEntity {
 
   private String description;
 
-  private int personnel;
+  private Long personnel;
 
   private LocalDate startPeriodAt;
 
   private LocalDate endPeriodAt;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
   @Enumerated(EnumType.STRING)
   private CourseStatus courseStatus;
+
+  public static Course toEntity(CourseReq courseReq, User user) {
+    return Course.builder()
+        .title(courseReq.getTitle())
+        .description(courseReq.getDescription())
+        .personnel(courseReq.getPersonnel())
+        .startPeriodAt(courseReq.getStartPeriodAt())
+        .endPeriodAt(courseReq.getEndPeriodAt())
+        .user(user)
+        .courseStatus(courseReq.getCourseStatus())
+        .build();
+  }
 
 }

--- a/src/main/java/com/example/assignment/domain/entity/Enrollment.java
+++ b/src/main/java/com/example/assignment/domain/entity/Enrollment.java
@@ -27,12 +27,12 @@ public class Enrollment extends BaseEntity {
   private Long enrollmentId;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "course_id")
-  private Course courseId;
+  @JoinColumn(name = "course_id", nullable = false)
+  private Course course;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_Id")
-  private User userId;
+  @JoinColumn(name = "user_Id", nullable = false)
+  private User user;
 
   @Enumerated(EnumType.STRING)
   private EnrollmentStatus enrollmentStatus;

--- a/src/main/java/com/example/assignment/domain/repository/CourseRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/CourseRepository.java
@@ -1,0 +1,35 @@
+package com.example.assignment.domain.repository;
+
+import com.example.assignment.domain.entity.Course;
+import com.example.assignment.domain.entity.User;
+import com.example.assignment.domain.type.CourseStatus;
+import java.time.LocalDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CourseRepository extends JpaRepository<Course, Long> {
+
+  @Query("""
+      SELECT COUNT(c) > 0
+      FROM Course c
+      WHERE c.user = :user
+        AND c.title = :title
+        AND c.description = :description
+        AND c.personnel = :personnel
+        AND c.startPeriodAt = :startPeriodAt
+        AND c.endPeriodAt = :endPeriodAt
+        AND c.courseStatus = :courseStatus
+      """)
+  boolean existsDuplicateCourse(
+      @Param("user") User user,
+      @Param("title") String title,
+      @Param("description") String description,
+      @Param("personnel") Long personnel,
+      @Param("startPeriodAt") LocalDate startPeriodAt,
+      @Param("endPeriodAt") LocalDate endPeriodAt,
+      @Param("courseStatus") CourseStatus courseStatus
+  );
+}

--- a/src/main/java/com/example/assignment/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.assignment.domain.repository;
+
+import com.example.assignment.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -7,6 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum FailedType {
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+  ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 작업에 대한 권한이 없습니다."),
+  COURSE_IS_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 등록한 강의 입니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum SuccessType {
+  SUCCESS_REGISTRATION_COURSE(HttpStatus.OK, "강의를 성공적으로 등록하였습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/service/CourseService.java
+++ b/src/main/java/com/example/assignment/service/CourseService.java
@@ -1,0 +1,10 @@
+package com.example.assignment.service;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import com.example.assignment.domain.dto.request.CourseReq;
+import jakarta.validation.Valid;
+
+public interface CourseService {
+
+  ResultResponse register(@Valid CourseReq courseReq);
+}

--- a/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
@@ -1,0 +1,53 @@
+package com.example.assignment.service.impl;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import com.example.assignment.domain.dto.request.CourseReq;
+import com.example.assignment.domain.entity.Course;
+import com.example.assignment.domain.entity.User;
+import com.example.assignment.domain.repository.CourseRepository;
+import com.example.assignment.domain.repository.UserRepository;
+import com.example.assignment.domain.type.FailedType;
+import com.example.assignment.domain.type.SuccessType;
+import com.example.assignment.domain.type.UserRole;
+import com.example.assignment.exception.GlobalException;
+import com.example.assignment.service.CourseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CourseServiceImpl implements CourseService {
+
+  private final UserRepository userRepository;
+  private final CourseRepository courseRepository;
+
+  @Override
+  public ResultResponse register(CourseReq courseReq) {
+
+    User user = userRepository.findById(courseReq.getUserId())
+        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+
+    // security 설정 없어서 임시로 설정
+    if(user.getUserRole().equals(UserRole.STUDENT)) {
+      throw new GlobalException(FailedType.ACCESS_DENIED);
+    }
+
+    boolean isDuplicate = courseRepository.existsDuplicateCourse(
+        user,
+        courseReq.getTitle(),
+        courseReq.getDescription(),
+        courseReq.getPersonnel(),
+        courseReq.getStartPeriodAt(),
+        courseReq.getEndPeriodAt(),
+        courseReq.getCourseStatus()
+    );
+
+    if(isDuplicate) throw new GlobalException(FailedType.COURSE_IS_DUPLICATE);
+
+    Course course = Course.toEntity(courseReq, user);
+
+    courseRepository.save(course);
+
+    return ResultResponse.of(SuccessType.SUCCESS_REGISTRATION_COURSE);
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,7 +12,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 작업 내용
> 강의 등록 API를 구현 및, 연관된 도메인(Course - User) 관계 정리, 응답 상수 및 중복 등록 방지 로직 구현

### 1. 강의 등록 API 구현

- `POST /api/v1/course` 엔드포인트 추가
- 요청 흐름: `CourseController` → `CourseService` → `CourseServiceImpl`
- 검증: `@Valid` 기반 DTO 검증 + 서비스 레이어에서 권한/중복 체크

### 2. Course - User 연관관계 추가

- `Course` 엔티티에 `User`(강사) 와의 `@ManyToOne(FetchType.LAZY)` 연관관계 추가
- `user_id` 컬럼 `nullable = false` 설정으로 강사 없는 강의 생성 차단

### 3. Enrollment 필드명 정리

- `courseId` → `course`, `userId` → `user` 로 네이밍 수정
   - 실제 매핑 객체는 PK가 아닌 엔티티 참조이므로, 객체 지향적 네이밍으로 정리
- `course_id`, `user_id` 모두 `nullable = false` 설정 추가

### 4. CourseReq DTO 구현

- 필드별 검증 애너테이션 적용 (`@NotBlank`, `@NotNull,` `@Min`, `@FutureOrPresent)`
- `@AssertTrue `기반 `isValidPeriod()` 로 시작일/종료일 선후 관계 검증

### 5. Repository 계층 구현

- `UserRepository`, `CourseRepository` 추가
- 중복 강의 검증용 `existsDuplicateCourse()` JPQL 메서드 구현

### 6. 응답/예외 상수 추가

- `SuccessType.SUCCESS_REGISTRATION_COURSE`
- `FailedType.USER_NOT_FOUND`, `ACCESS_DENIED`, `COURSE_IS_DUPLICATE`

### 7. 설정 변경

`ddl-auto: create` → `update` 로 변경 (개발 중 데이터 유실 방지)

---

### 중복 검증 메서드 설계

> 강의 중복 여부 강사 + 강의 정보 전체 일치를 기준으로 설계.

이유 : 
- 같은 강사가 서로 다른 강의를 개설하는 경우 → 제목이 달라지므로 다른 강의로 인정되어야 함
- 같은 강의를 다른 기간에 재개설하는 경우 (예: 1기, 2기 모집)→ 제목/내용은 같아도 모집 기간이 다르면 별개의 강의로 인정되어야 함
- 완전히 동일한 강의(강사, 제목, 설명, 인원, 기간, 상태 모두 일치)를 실수로 중복 등록하는 경우→ 이 케이스만 막는 것이 목표