### PR TITLE
[Feat] 과제 A - 강의 목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ dependencies {
 
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // Infra
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/example/assignment/config/QueryDslConfig.java
+++ b/src/main/java/com/example/assignment/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.example.assignment.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/example/assignment/controller/CourseController.java
+++ b/src/main/java/com/example/assignment/controller/CourseController.java
@@ -2,13 +2,18 @@ package com.example.assignment.controller;
 
 import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.domain.dto.request.CourseReq;
+import com.example.assignment.domain.type.CourseStatus;
 import com.example.assignment.service.CourseService;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,6 +27,30 @@ public class CourseController {
   public ResponseEntity<ResultResponse> register(@RequestBody @Valid CourseReq courseReq) {
 
     ResultResponse response = courseService.register(courseReq);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @GetMapping
+  public ResponseEntity<ResultResponse> getCourses(
+      @RequestParam(required = false) String creatorName,
+      @RequestParam(required = false) String title,
+      @RequestParam(required = false) Long minAmount,
+      @RequestParam(required = false) Long maxAmount,
+      @RequestParam(required = false) LocalDate startPeriodAt,
+      @RequestParam(required = false) LocalDate endPeriodAt,
+      @RequestParam(required = false) CourseStatus courseStatus,
+      @RequestParam(defaultValue = "1") int page
+  ) {
+    ResultResponse response = courseService.getCourses(creatorName, title,
+        minAmount, maxAmount, startPeriodAt, endPeriodAt, courseStatus, page);
+
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @GetMapping("/{courseId}")
+  public ResponseEntity<ResultResponse> getCourseDetail(@PathVariable Long courseId) {
+
+    ResultResponse response = courseService.getCourseDetail(courseId);
     return new ResponseEntity<>(response, response.getStatus());
   }
 

--- a/src/main/java/com/example/assignment/domain/dto/request/CourseSearchReq.java
+++ b/src/main/java/com/example/assignment/domain/dto/request/CourseSearchReq.java
@@ -1,0 +1,26 @@
+package com.example.assignment.domain.dto.request;
+
+import com.example.assignment.domain.type.CourseStatus;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CourseSearchReq {
+
+  private String creatorName;
+
+  private String title;
+
+  private Long minAmount;
+
+  private Long maxAmount;
+
+  private LocalDate startPeriodAt;
+
+  private LocalDate endPeriodAt;
+
+  private CourseStatus courseStatus;
+
+}

--- a/src/main/java/com/example/assignment/domain/dto/response/CoursePageRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/CoursePageRes.java
@@ -1,0 +1,44 @@
+package com.example.assignment.domain.dto.response;
+
+import com.example.assignment.domain.entity.Course;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CoursePageRes {
+
+  private Long courseId;
+
+  private String title;
+
+  private String description;
+
+  private String creatorName;
+
+  private String courseStatus;
+
+  private LocalDate startPeriodAt;
+
+  private LocalDate endPeriodAt;
+
+  public static List<CoursePageRes> toCourseResList(List<Course> list) {
+    return list.stream()
+        .map(course ->
+            new CoursePageRes(
+                course.getCourseId(),
+                course.getTitle(),
+                course.getDescription(),
+                course.getUser().getName(),
+                course.getCourseStatus().getValue(),
+                course.getStartPeriodAt(),
+                course.getEndPeriodAt()
+            )
+        )
+        .toList();
+  }
+}

--- a/src/main/java/com/example/assignment/domain/dto/response/CourseRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/CourseRes.java
@@ -1,0 +1,47 @@
+package com.example.assignment.domain.dto.response;
+
+import com.example.assignment.domain.entity.Course;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CourseRes {
+
+  private Long courseId;
+
+  private String title;
+
+  private String description;
+
+  private String creatorName;
+
+  private String courseStatus;
+
+  private LocalDate startPeriodAt;
+
+  private LocalDate endPeriodAt;
+
+  private String amount;
+
+  private String enrollmentRatio;
+
+  public static CourseRes toCourseRes(Course course) {
+    return new CourseRes(
+        course.getCourseId(),
+        course.getTitle(),
+        course.getDescription(),
+        course.getUser().getName(),
+        course.getCourseStatus().getValue(),
+        course.getStartPeriodAt(),
+        course.getEndPeriodAt(),
+        String.format("%,d원", course.getAmount()),
+        course.getEnrollmentCnt() + " / " + course.getPersonnel()
+    );
+  }
+
+}

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -47,6 +47,8 @@ public class Course extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private CourseStatus courseStatus;
 
+  private Long enrollmentCnt;
+
   public static Course toEntity(CourseReq courseReq, User user) {
     return Course.builder()
         .title(courseReq.getTitle())
@@ -57,6 +59,7 @@ public class Course extends BaseEntity {
         .endPeriodAt(courseReq.getEndPeriodAt())
         .user(user)
         .courseStatus(courseReq.getCourseStatus())
+        .enrollmentCnt(0L)
         .build();
   }
 

--- a/src/main/java/com/example/assignment/domain/repository/querydsl/CourseQueryRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/querydsl/CourseQueryRepository.java
@@ -1,0 +1,69 @@
+package com.example.assignment.domain.repository.querydsl;
+
+import com.example.assignment.domain.entity.Course;
+import com.example.assignment.domain.entity.QCourse;
+import com.example.assignment.domain.type.CourseStatus;
+import com.example.assignment.domain.type.UserRole;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CourseQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  public List<Course> searchCourses(String creatorName, String title, Long minAmount, Long maxAmount,
+      LocalDate startPeriodAt, LocalDate endPeriodAt, CourseStatus courseStatus) {
+    QCourse course = QCourse.course;
+
+    return queryFactory
+        .selectFrom(course)
+        .leftJoin(course.user).fetchJoin()
+        .where(
+            creatorNameEq(creatorName),
+            titleContains(title),
+            amountGoe(minAmount),
+            amountLoe(maxAmount),
+            startPeriodAtGoe(startPeriodAt),
+            endPeriodAtLoe(endPeriodAt),
+            courseStatusEq(courseStatus)
+        )
+        .fetch();
+  }
+
+  // null이면 조건 자체를 제외 (동적 쿼리 핵심)
+  private BooleanExpression creatorNameEq(String name) {
+    return name == null ? null : QCourse.course.user.name.eq(name)
+        .and(QCourse.course.user.userRole.eq(UserRole.CREATORS));
+  }
+
+  private BooleanExpression titleContains(String title) {
+    return title == null ? null : QCourse.course.title.contains(title);
+  }
+
+  private BooleanExpression amountGoe(Long minAmount) {
+    return minAmount == null ? null : QCourse.course.amount.goe(minAmount);
+  }
+
+  private BooleanExpression amountLoe(Long maxAmount) {
+    return maxAmount == null ? null : QCourse.course.amount.loe(maxAmount);
+  }
+
+  private BooleanExpression startPeriodAtGoe(LocalDate date) {
+    return date == null ? null : QCourse.course.startPeriodAt.goe(date);
+  }
+
+  private BooleanExpression endPeriodAtLoe(LocalDate date) {
+    return date == null ? null : QCourse.course.endPeriodAt.loe(date);
+  }
+
+  private BooleanExpression courseStatusEq(CourseStatus status) {
+    return status == null ? null : QCourse.course.courseStatus.eq(status);
+  }
+
+}

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -10,6 +10,7 @@ public enum FailedType {
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
   ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 작업에 대한 권한이 없습니다."),
   COURSE_IS_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 등록한 강의 입니다."),
+  COURSE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 강의 입니다.."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessType {
   SUCCESS_REGISTRATION_COURSE(HttpStatus.OK, "강의를 성공적으로 등록하였습니다."),
+  SUCCESS_INQUIRY_COURSES(HttpStatus.OK, "강의목록을 성공적으로 조회하였습니다."),
+  SUCCESS_INQUIRY_COURSES_DETAIL(HttpStatus.OK, "강의 상세 정보를 성공적으로 조회하였습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/service/CourseService.java
+++ b/src/main/java/com/example/assignment/service/CourseService.java
@@ -2,9 +2,16 @@ package com.example.assignment.service;
 
 import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.domain.dto.request.CourseReq;
+import com.example.assignment.domain.type.CourseStatus;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 
 public interface CourseService {
 
   ResultResponse register(@Valid CourseReq courseReq);
+
+  ResultResponse getCourses(String creatorName, String title, Long minAmount, Long maxAmount,
+      LocalDate startPeriodAt, LocalDate endPeriodAt, CourseStatus courseStatus, int page);
+
+  ResultResponse getCourseDetail(Long courseId);
 }

--- a/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
@@ -83,6 +83,6 @@ public class CourseServiceImpl implements CourseService {
         .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
 
     CourseRes courseRes = CourseRes.toCourseRes(course);
-    return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSES, courseRes);
+    return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSES_DETAIL, courseRes);
   }
 }

--- a/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
@@ -1,18 +1,26 @@
 package com.example.assignment.service.impl;
 
+import com.example.assignment.domain.dto.PageResponse;
 import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.domain.dto.request.CourseReq;
+import com.example.assignment.domain.dto.response.CoursePageRes;
+import com.example.assignment.domain.dto.response.CourseRes;
 import com.example.assignment.domain.entity.Course;
 import com.example.assignment.domain.entity.User;
 import com.example.assignment.domain.repository.CourseRepository;
 import com.example.assignment.domain.repository.UserRepository;
+import com.example.assignment.domain.repository.querydsl.CourseQueryRepository;
+import com.example.assignment.domain.type.CourseStatus;
 import com.example.assignment.domain.type.FailedType;
 import com.example.assignment.domain.type.SuccessType;
 import com.example.assignment.domain.type.UserRole;
 import com.example.assignment.exception.GlobalException;
 import com.example.assignment.service.CourseService;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +28,7 @@ public class CourseServiceImpl implements CourseService {
 
   private final UserRepository userRepository;
   private final CourseRepository courseRepository;
+  private final CourseQueryRepository courseQueryRepository;
 
   @Override
   public ResultResponse register(CourseReq courseReq) {
@@ -50,5 +59,30 @@ public class CourseServiceImpl implements CourseService {
     courseRepository.save(course);
 
     return ResultResponse.of(SuccessType.SUCCESS_REGISTRATION_COURSE);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public ResultResponse getCourses(String creatorName, String title, Long minAmount, Long maxAmount,
+      LocalDate startPeriodAt, LocalDate endPeriodAt, CourseStatus courseStatus, int page) {
+
+    List<Course> courses = courseQueryRepository.searchCourses(creatorName, title, minAmount,
+        maxAmount, startPeriodAt, endPeriodAt, courseStatus);
+
+    List<CoursePageRes> courseRes = CoursePageRes.toCourseResList(courses);
+
+    PageResponse<CoursePageRes> pageResponse = PageResponse.pagination(courseRes, page);
+    return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSES, pageResponse);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public ResultResponse getCourseDetail(Long courseId) {
+
+    Course course = courseRepository.findById(courseId)
+        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+
+    CourseRes courseRes = CourseRes.toCourseRes(course);
+    return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSES, courseRes);
   }
 }


### PR DESCRIPTION
## 작업 내용
> 다양한 조건으로 강의를 검색하고 상세 정보를 조회할 수 있는 API 구현
> 동적 쿼리 처리를 위해 QueryDSL을 도입하고, 관련 DTO 및 응답 포맷 정비

### QueryDSL 도입

- `build.gradle`에 QueryDSL 의존성 추가
- `QueryDslConfig` 등록 (`JPAQueryFactory` Bean 설정)

###  강의 목록 조회 API

- `GET /api/v1/course` 엔드포인트 추가
- 지원 검색 조건:
   - 강사명(`creatorName`) — CREATORS 권한 보유자만 매칭
   - 강의 제목(`title`) — LIKE 검색
   - 가격 범위(`minAmount`, `maxAmount`)
   - 기간 범위(`startPeriodAt`, `endPeriodAt`)
   - 강의 상태(`courseStatus`)
- 모든 파라미터는 선택(`required = false`) — 조건부 동적 검색
- 페이지네이션 적용(기본 1페이지, 10개씩)

### 강의 상세 조회 API

- `GET /api/v1/course/{courseId}` 엔드포인트 추가
- 존재하지 않는 강의 조회 시 `COURSE_NOT_FOUND` 예외 처리 

### 응답 DTO 분리

- `CoursePageRes` — 목록 조회용 (간소화된 필드)
- `CourseRes` — 상세 조회용 (금액 포맷팅, 수강 비율 등 풍부한 정보)
- 용도에 따른 DTO 분리로 불필요한 데이터 전송 최소화

### 강의 엔티티에 수강 인원 컬럼 추가

- `Course.enrollmentCnt `(Long) 필드 추가
- 생성 시점 기본값 `0L` 로 초기화
- 향후 수강 신청 시 증감 로직과 연결 예정

### 성능/트랜잭션 최적화

- 조회 메서드에 `@Transactional(readOnly = true)` 적용
   - dirty checking 비활성화로 성능 향상
   - 명시적인 읽기 전용 메서드 표현
   
   ### 응답 상수 추가

- `SuccessType.SUCCESS_INQUIRY_COURSES` (강의 목록 조회 성공)
- `SuccessType.SUCCESS_INQUIRY_COURSES_DETAIL` (강의 상세 조회 성공)
- `FailedType.COURSE_NOT_FOUND` (존재하지 않는 강의)


---

### QueryDSL 을 선택한 이유

- `@Query` JPQL 의 한계
   - 조건 개수만큼 분기 쿼리를 작성해야 함
   - `WHERE 1=1 AND ...` 같은 편법 패턴 필요
   - 조건이 추가될 때마다 쿼리 전체를 수정해야 함


- QueryDSL 의 장점
   - `BooleanExpression` 으로 조건을 메서드 단위로 분리 가능
   - `null` 값은 `where()` 절에서 자동으로 무시됨
   - 조건이 늘어도 쿼리 구조가 깨지지 않아 유지보수성 우수 