### PR TITLE
[Feat] 과제 A - 수강신청 API 구현

### DIFF
--- a/src/main/java/com/example/assignment/controller/EnrollmentController.java
+++ b/src/main/java/com/example/assignment/controller/EnrollmentController.java
@@ -1,0 +1,33 @@
+package com.example.assignment.controller;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import com.example.assignment.service.EnrollmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/enrollment")
+@RequiredArgsConstructor
+public class EnrollmentController {
+
+  private final EnrollmentService enrollmentService;
+
+  @PostMapping("/{userId}/{courseId}")
+  public ResponseEntity<ResultResponse> enroll(@PathVariable Long userId, @PathVariable Long courseId) {
+
+    ResultResponse response = enrollmentService.enroll(userId, courseId);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @PatchMapping("/{userId}/{enrollmentId}/pay")
+  public ResponseEntity<ResultResponse> payEnroll(@PathVariable Long userId, @PathVariable Long enrollmentId) {
+
+    ResultResponse response = enrollmentService.payEnroll(userId, enrollmentId);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+}

--- a/src/main/java/com/example/assignment/domain/dto/request/CourseReq.java
+++ b/src/main/java/com/example/assignment/domain/dto/request/CourseReq.java
@@ -2,7 +2,6 @@ package com.example.assignment.domain.dto.request;
 
 import com.example.assignment.domain.type.CourseStatus;
 import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -63,4 +63,22 @@ public class Course extends BaseEntity {
         .build();
   }
 
+  public boolean isFull() {
+    return enrollmentCnt >= personnel;
+  }
+
+  public void increaseEnrollmentCnt() {
+    this.enrollmentCnt++;
+
+    // 정원이 꽉 찼으면 자동으로 CLOSED 로 변경
+    if (this.isFull()) {
+      this.courseStatus = CourseStatus.CLOSED;
+    }
+  }
+
+  public boolean isNotAvailable() {
+    return courseStatus == CourseStatus.DRAFT
+        || courseStatus == CourseStatus.CLOSED;
+  }
+
 }

--- a/src/main/java/com/example/assignment/domain/entity/Enrollment.java
+++ b/src/main/java/com/example/assignment/domain/entity/Enrollment.java
@@ -37,4 +37,23 @@ public class Enrollment extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private EnrollmentStatus enrollmentStatus;
 
+  public static Enrollment toEntity(Course course, User user) {
+    return Enrollment.builder()
+        .course(course)
+        .user(user)
+        .enrollmentStatus(EnrollmentStatus.PENDING)
+        .build();
+  }
+
+  public boolean isConfirmed() {
+    return enrollmentStatus == EnrollmentStatus.CONFIRMED;
+  }
+
+  public boolean isCancelled() {
+    return enrollmentStatus == EnrollmentStatus.CANCELLED;
+  }
+
+  public void confirm() {
+    this.enrollmentStatus = EnrollmentStatus.CONFIRMED;
+  }
 }

--- a/src/main/java/com/example/assignment/domain/entity/User.java
+++ b/src/main/java/com/example/assignment/domain/entity/User.java
@@ -27,4 +27,12 @@ public class User {
 
   @Enumerated(EnumType.STRING)
   private UserRole userRole;
+
+  public boolean isStudent() {
+    return userRole == UserRole.STUDENT;
+  }
+
+  public boolean isCreator() {
+    return userRole == UserRole.CREATORS;
+  }
 }

--- a/src/main/java/com/example/assignment/domain/repository/CourseRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/CourseRepository.java
@@ -3,8 +3,11 @@ package com.example.assignment.domain.repository;
 import com.example.assignment.domain.entity.Course;
 import com.example.assignment.domain.entity.User;
 import com.example.assignment.domain.type.CourseStatus;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -34,4 +37,8 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
       @Param("endPeriodAt") LocalDate endPeriodAt,
       @Param("courseStatus") CourseStatus courseStatus
   );
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT c FROM Course c WHERE c.courseId = :courseId")
+  Optional<Course> findByIdWithLock(@Param("courseId") Long courseId);
 }

--- a/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
@@ -1,0 +1,14 @@
+package com.example.assignment.domain.repository;
+
+import com.example.assignment.domain.entity.Course;
+import com.example.assignment.domain.entity.Enrollment;
+import com.example.assignment.domain.entity.User;
+import com.example.assignment.domain.type.EnrollmentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+
+  boolean existsByCourseAndUserAndEnrollmentStatusNot(Course course, User user, EnrollmentStatus status);
+}

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -11,6 +11,12 @@ public enum FailedType {
   ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 작업에 대한 권한이 없습니다."),
   COURSE_IS_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 등록한 강의 입니다."),
   COURSE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 강의 입니다.."),
+  COURSE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "현재 수강신청이 불가능한 강의입니다."),
+  COURSE_IS_FULL(HttpStatus.BAD_REQUEST, "수강 정원이 마감되었습니다."),
+  ALREADY_ENROLLED(HttpStatus.CONFLICT, "이미 수강신청한 강의입니다."),
+  ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 수강신청 내역입니다."),
+  ALREADY_PAID(HttpStatus.BAD_REQUEST, "이미 결제가 완료된 수강신청입니다."),
+  ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 수강신청입니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -10,6 +10,8 @@ public enum SuccessType {
   SUCCESS_REGISTRATION_COURSE(HttpStatus.OK, "강의를 성공적으로 등록하였습니다."),
   SUCCESS_INQUIRY_COURSES(HttpStatus.OK, "강의목록을 성공적으로 조회하였습니다."),
   SUCCESS_INQUIRY_COURSES_DETAIL(HttpStatus.OK, "강의 상세 정보를 성공적으로 조회하였습니다."),
+  SUCCESS_ENROLLMENT(HttpStatus.OK, "수강신청이 성공적으로 완료되었습니다."),
+  SUCCESS_PAYMENT(HttpStatus.OK, "결제가 성공적으로 완료되었습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/service/EnrollmentService.java
+++ b/src/main/java/com/example/assignment/service/EnrollmentService.java
@@ -1,0 +1,10 @@
+package com.example.assignment.service;
+
+import com.example.assignment.domain.dto.ResultResponse;
+
+public interface EnrollmentService {
+
+  ResultResponse enroll(Long userId, Long courseId);
+
+  ResultResponse payEnroll(Long userId, Long enrollmentId);
+}

--- a/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
@@ -13,7 +13,6 @@ import com.example.assignment.domain.repository.querydsl.CourseQueryRepository;
 import com.example.assignment.domain.type.CourseStatus;
 import com.example.assignment.domain.type.FailedType;
 import com.example.assignment.domain.type.SuccessType;
-import com.example.assignment.domain.type.UserRole;
 import com.example.assignment.exception.GlobalException;
 import com.example.assignment.service.CourseService;
 import java.time.LocalDate;
@@ -37,7 +36,7 @@ public class CourseServiceImpl implements CourseService {
         .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
 
     // security 설정 없어서 임시로 설정
-    if(user.getUserRole().equals(UserRole.STUDENT)) {
+    if (user.isStudent()) {
       throw new GlobalException(FailedType.ACCESS_DENIED);
     }
 

--- a/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
@@ -1,0 +1,86 @@
+package com.example.assignment.service.impl;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import com.example.assignment.domain.entity.Course;
+import com.example.assignment.domain.entity.Enrollment;
+import com.example.assignment.domain.entity.User;
+import com.example.assignment.domain.repository.CourseRepository;
+import com.example.assignment.domain.repository.EnrollmentRepository;
+import com.example.assignment.domain.repository.UserRepository;
+import com.example.assignment.domain.type.EnrollmentStatus;
+import com.example.assignment.domain.type.FailedType;
+import com.example.assignment.domain.type.SuccessType;
+import com.example.assignment.exception.GlobalException;
+import com.example.assignment.service.EnrollmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EnrollmentServiceImpl implements EnrollmentService {
+
+  private final EnrollmentRepository enrollmentRepository;
+  private final CourseRepository courseRepository;
+  private final UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public ResultResponse enroll(Long userId, Long courseId) {
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+
+    if (user.isCreator()) {
+      throw new GlobalException(FailedType.ACCESS_DENIED);
+    }
+
+    Course course = courseRepository.findByIdWithLock(courseId)
+        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+
+    if (course.isNotAvailable()) {
+      throw new GlobalException(FailedType.COURSE_NOT_AVAILABLE);
+    }
+
+    if (course.isFull()) {
+      throw new GlobalException(FailedType.COURSE_IS_FULL);
+    }
+
+    if (enrollmentRepository.existsByCourseAndUserAndEnrollmentStatusNot(course, user, EnrollmentStatus.CANCELLED)) {
+
+      throw new GlobalException(FailedType.ALREADY_ENROLLED);
+    }
+
+    Enrollment enrollment = Enrollment.toEntity(course, user);
+    enrollmentRepository.save(enrollment);
+
+    course.increaseEnrollmentCnt();
+
+    return ResultResponse.of(SuccessType.SUCCESS_ENROLLMENT);
+  }
+
+
+  @Override
+  @Transactional
+  public ResultResponse payEnroll(Long userId, Long enrollmentId) {
+
+    Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
+        .orElseThrow(() -> new GlobalException(FailedType.ENROLLMENT_NOT_FOUND));
+
+    if (!enrollment.getUser().getUserId().equals(userId)) {
+      throw new GlobalException(FailedType.ACCESS_DENIED);
+    }
+
+    if (enrollment.isConfirmed()) {
+      throw new GlobalException(FailedType.ALREADY_PAID);
+    }
+
+    if (enrollment.isCancelled()) {
+      throw new GlobalException(FailedType.ALREADY_CANCELLED);
+    }
+
+    enrollment.confirm();
+
+    return ResultResponse.of(SuccessType.SUCCESS_PAYMENT);
+  }
+}


### PR DESCRIPTION
## 작업 내용
> 학생이 강의를 신청하고 결제까지 진행할 수 있는 API구현
> 정원 관리의 동시성 이슈를 비관적 락(Pessimistic Lock)으로 해결하고, 비즈니스 규칙을 엔티티에 응집시키는 방향으로 설계

## 주요 변경사항

### 수강신청 API 구현
- `POST /api/v1/enrollment/{userId}/{courseId}` 엔드포인트 추가
- 검증 순서: 사용자 존재 → 권한(학생인가) → 강의 상태 → 정원 → 중복 신청
- 신청 성공 시 `Enrollment` 를 `PENDING` 상태로 저장
- `Course.enrollmentCnt` 증가 처리

### 결제 API 구현
- `PATCH /api/v1/enrollment/{userId}/{enrollmentId}/pay` 엔드포인트 추가
- 검증 순서: 수강신청 존재 → 본인 신청 여부 → 결제 가능 상태 확인
- `Enrollment` 상태 전환: `PENDING` → `CONFIRMED`

### 동시성 제어 (비관적 락)
- `CourseRepository.findByIdWithLock()` 메서드 추가
- `@Lock(LockModeType.PESSIMISTIC_WRITE)` 로 `SELECT ... FOR UPDATE` 적용
- 수강신청 시점에만 락 획득 → 정원 경합 상황 방지

### 도메인 메서드 추가 (비즈니스 규칙 응집)
- **User**
  - `isStudent()`, `isCreator()` : 역할 판별
- **Course**
  - `isNotAvailable()` : 모집 불가 상태 여부 (DRAFT / CLOSED)
  - `isFull()` : 정원 마감 여부
  - `increaseEnrollmentCnt()` : 인원 증가 + 정원 마감 시 자동 CLOSED 전환
- **Enrollment**
  - `isConfirmed()`, `isCancelled()` : 상태 판별
  - `confirm()` : PENDING → CONFIRMED 상태 전환
  - `toEntity()` : 정적 팩토리 메서드

### 5. 중복 신청 로직 개선
- `existsByCourseAndUserAndEnrollmentStatusNot()` 로 **CANCELLED 상태는 제외**
- 취소 후 재신청이 가능하도록 정책 반영

### 6. 응답 상수 추가
- **성공**
  - `SUCCESS_ENROLLMENT` (수강신청 완료)
  - `SUCCESS_PAYMENT` (결제 완료)
- **실패**
  - `COURSE_NOT_AVAILABLE` (모집 불가 상태)
  - `COURSE_IS_FULL` (정원 마감)
  - `ALREADY_ENROLLED` (이미 신청한 강의) - 409 Conflict
  - `ENROLLMENT_NOT_FOUND` (존재하지 않는 수강신청)
  - `ALREADY_PAID` (이미 결제 완료)
  - `ALREADY_CANCELLED` (이미 취소됨)

---

### 비관적 락을 선택한 이유
수강신청은 **정원이 남은 마지막 자리에 여러 사용자가 동시에 신청**하는 경합이 필연적으로 발생.

- **낙관적 락**은 충돌 시 재시도 방식이라, 경합이 잦은 수강신청 시나리오에선 재시도 비용이 큼
- **비관적 락**은 DB 레벨에서 순차 처리를 보장해 정원 초과를 확실히 방지할 수 있음

`SELECT ... FOR UPDATE` 쿼리로 `Course` 행에 X-Lock 을 걸어, 트랜잭션이 끝날 때까지 다른 신청자가 대기하도록 처리

### 락이 필요한 지점과 불필요한 지점 구분
락은 `Course.enrollmentCnt` 를 수정하는 지점에만 적용

| 시점 | 수정 대상 | 락 필요 여부 |
|---|---|---|
| 수강신청 | `Course.enrollmentCnt` 증가 | 필요 |
| 결제 | `Enrollment.status` 변경 | 불필요 |
| 수강취소 (추후) | `Course.enrollmentCnt` 감소 | 필요 |

결제는 각 사용자의 `Enrollment` 행만 수정하므로 경합이 없어 락을 생략함. 대신 상태 검증 (`isConfirmed`, `isCancelled`) 으로 중복 결제와 상태 충돌을 예방.

### 엔티티에 비즈니스 규칙 응집
정원 마감 시 상태를 CLOSED 로 자동 전환하는 로직을 서비스가 아닌 `Course.increaseEnrollmentCnt()` 내부에서 처리함. 동일한 규칙이 여러 곳에 흩어지지 않도록 엔티티에 응집시켜, 불변식(invariant) 을 코드 레벨에서 강제함.