### PR TITLE
[Feat] 과제 A - 내 수강 신청 목록 조회

### DIFF
--- a/src/main/java/com/example/assignment/controller/EnrollmentController.java
+++ b/src/main/java/com/example/assignment/controller/EnrollmentController.java
@@ -4,10 +4,12 @@ import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.service.EnrollmentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,6 +30,13 @@ public class EnrollmentController {
   public ResponseEntity<ResultResponse> payEnroll(@PathVariable Long userId, @PathVariable Long enrollmentId) {
 
     ResultResponse response = enrollmentService.payEnroll(userId, enrollmentId);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @GetMapping("/{userId}")
+  public ResponseEntity<ResultResponse> getEnroll(@PathVariable Long userId, @RequestParam(defaultValue = "1") int page ) {
+
+    ResultResponse response = enrollmentService.getEnroll(userId, page);
     return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/src/main/java/com/example/assignment/domain/dto/response/EnrollmentPageRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/EnrollmentPageRes.java
@@ -1,0 +1,56 @@
+package com.example.assignment.domain.dto.response;
+
+import com.example.assignment.domain.entity.Course;
+import com.example.assignment.domain.entity.Enrollment;
+import com.example.assignment.domain.type.EnrollmentStatus;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EnrollmentPageRes {
+
+  private Long enrollmentId;
+
+  private Long courseId;
+
+  private String title;
+
+  private String description;
+
+  private String creatorName;
+
+  private String courseStatus;
+
+  private LocalDate startPeriodAt;
+
+  private LocalDate endPeriodAt;
+
+  private String enrollmentRatio;
+
+  private String enrollmentStatus;
+
+  public static List<EnrollmentPageRes> toEnrollmentPageList(List<Enrollment> list) {
+    return list.stream()
+        .map(enrollment ->
+            new EnrollmentPageRes(
+                enrollment.getEnrollmentId(),
+                enrollment.getCourse().getCourseId(),
+                enrollment.getCourse().getTitle(),
+                enrollment.getCourse().getDescription(),
+                enrollment.getCourse().getUser().getName(),
+                enrollment.getCourse().getCourseStatus().getValue(),
+                enrollment.getCourse().getStartPeriodAt(),
+                enrollment.getCourse().getEndPeriodAt(),
+                enrollment.getCourse().getEnrollmentCnt() + " / " + enrollment.getCourse().getPersonnel(),
+                enrollment.getEnrollmentStatus().getValue()
+            )
+        )
+        .toList();
+  }
+
+}

--- a/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
@@ -4,11 +4,22 @@ import com.example.assignment.domain.entity.Course;
 import com.example.assignment.domain.entity.Enrollment;
 import com.example.assignment.domain.entity.User;
 import com.example.assignment.domain.type.EnrollmentStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
   boolean existsByCourseAndUserAndEnrollmentStatusNot(Course course, User user, EnrollmentStatus status);
+
+  @Query("""
+    SELECT e FROM Enrollment e
+    JOIN FETCH e.course
+    WHERE e.user = :user
+    ORDER BY e.createdAt DESC
+    """)
+  List<Enrollment> findAllByUserWithCourse(@Param("user") User user);
 }

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -8,11 +8,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessType {
   SUCCESS_REGISTRATION_COURSE(HttpStatus.OK, "강의를 성공적으로 등록하였습니다."),
-  SUCCESS_INQUIRY_COURSES(HttpStatus.OK, "강의목록을 성공적으로 조회하였습니다."),
+  SUCCESS_INQUIRY_COURSES(HttpStatus.OK, "강의 목록을 성공적으로 조회하였습니다."),
   SUCCESS_INQUIRY_COURSES_DETAIL(HttpStatus.OK, "강의 상세 정보를 성공적으로 조회하였습니다."),
   SUCCESS_ENROLLMENT(HttpStatus.OK, "수강신청이 성공적으로 완료되었습니다."),
   SUCCESS_PAYMENT(HttpStatus.OK, "결제가 성공적으로 완료되었습니다."),
-  ;
+  SUCCESS_INQUIRY_ENROLLMENTS(HttpStatus.OK, "내 수강 신청 목록을 성공적으로 조회하였습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/example/assignment/service/EnrollmentService.java
+++ b/src/main/java/com/example/assignment/service/EnrollmentService.java
@@ -7,4 +7,6 @@ public interface EnrollmentService {
   ResultResponse enroll(Long userId, Long courseId);
 
   ResultResponse payEnroll(Long userId, Long enrollmentId);
+
+  ResultResponse getEnroll(Long userId, int page);
 }

--- a/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
@@ -1,6 +1,8 @@
 package com.example.assignment.service.impl;
 
+import com.example.assignment.domain.dto.PageResponse;
 import com.example.assignment.domain.dto.ResultResponse;
+import com.example.assignment.domain.dto.response.EnrollmentPageRes;
 import com.example.assignment.domain.entity.Course;
 import com.example.assignment.domain.entity.Enrollment;
 import com.example.assignment.domain.entity.User;
@@ -12,6 +14,7 @@ import com.example.assignment.domain.type.FailedType;
 import com.example.assignment.domain.type.SuccessType;
 import com.example.assignment.exception.GlobalException;
 import com.example.assignment.service.EnrollmentService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -82,5 +85,21 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     enrollment.confirm();
 
     return ResultResponse.of(SuccessType.SUCCESS_PAYMENT);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public ResultResponse getEnroll(Long userId, int page) {
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+
+    List<Enrollment> enrollments = enrollmentRepository.findAllByUserWithCourse(user);
+    List<EnrollmentPageRes> enrollmentPageRes = EnrollmentPageRes.toEnrollmentPageList(enrollments);
+
+    PageResponse<EnrollmentPageRes> enrollPageRes = PageResponse.pagination(enrollmentPageRes, page);
+
+    return new ResultResponse(SuccessType.SUCCESS_INQUIRY_ENROLLMENTS, enrollPageRes);
+
   }
 }


### PR DESCRIPTION
## 작업 내용
> 사용자가 본인의 수강신청 내역을 확인할 수 있는 조회 API 구현
> N+1 문제 방지를 위해 `fetchJoin` 을 적용하고, 페이징 처리로 대량 데이터에도 대응 가능하도록 설계

## 주요 변경사항

### 수강신청 내역 조회 API 구현
- `GET /api/v1/enrollment/{userId}` 엔드포인트 추가
- 쿼리 파라미터로 `page` 를 받아 페이징 처리 (기본값 1)
- 사용자의 신청 내역을 최신순으로 정렬하여 반환

### N+1 문제 방지를 위한 fetchJoin 적용
- `EnrollmentRepository.findAllByUserWithCourse()` 추가
- `JOIN FETCH e.course` 로 Course 를 함께 조회 → 추가 쿼리 발생 방지
- `ORDER BY e.createdAt DESC` 로 최신순 정렬 적용

### 조회 전용 DTO 추가
- `EnrollmentPageRes` : 수강신청 내역 목록 응답 DTO
- 포함 정보: 강의 제목, 설명, 강사명, 강의 상태, 기간, 수강 인원 비율, 신청 상태
- `toEnrollmentPageList()` 정적 팩토리 메서드로 리스트 변환 처리

### 응답 상수 추가
- `SUCCESS_INQUIRY_ENROLLMENTS` (내 수강신청 목록 조회 성공)
- `SUCCESS_INQUIRY_COURSES` 메시지 오탈자 수정 (`강의목록` → `강의 목록`)