### PR TITLE
[Feat] 과제 A - 수강 취소 API 구현 

### DIFF
--- a/src/main/java/com/example/assignment/controller/EnrollmentController.java
+++ b/src/main/java/com/example/assignment/controller/EnrollmentController.java
@@ -4,6 +4,7 @@ import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.service.EnrollmentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -37,6 +38,13 @@ public class EnrollmentController {
   public ResponseEntity<ResultResponse> getEnroll(@PathVariable Long userId, @RequestParam(defaultValue = "1") int page ) {
 
     ResultResponse response = enrollmentService.getEnroll(userId, page);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @DeleteMapping("/{userId}/{enrollmentId}")
+  public ResponseEntity<ResultResponse> cancelled(@PathVariable Long userId, @PathVariable Long enrollmentId) {
+
+    ResultResponse response = enrollmentService.cancelEnroll(userId, enrollmentId);
     return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -81,4 +81,15 @@ public class Course extends BaseEntity {
         || courseStatus == CourseStatus.CLOSED;
   }
 
+  public void decreaseEnrollmentCnt() {
+    if (this.enrollmentCnt > 0) {
+      this.enrollmentCnt--;
+    }
+
+    // CLOSED 상태였는데 자리가 나면 자동으로 OPEN 복귀
+    if (this.courseStatus == CourseStatus.CLOSED && !this.isFull()) {
+      this.courseStatus = CourseStatus.OPEN;
+    }
+  }
+
 }

--- a/src/main/java/com/example/assignment/domain/entity/Enrollment.java
+++ b/src/main/java/com/example/assignment/domain/entity/Enrollment.java
@@ -45,6 +45,10 @@ public class Enrollment extends BaseEntity {
         .build();
   }
 
+  public boolean isNotOwnedBy(Long userId) {
+    return !this.user.getUserId().equals(userId);
+  }
+
   public boolean isConfirmed() {
     return enrollmentStatus == EnrollmentStatus.CONFIRMED;
   }
@@ -55,5 +59,9 @@ public class Enrollment extends BaseEntity {
 
   public void confirm() {
     this.enrollmentStatus = EnrollmentStatus.CONFIRMED;
+  }
+
+  public void cancel() {
+    this.enrollmentStatus = EnrollmentStatus.CANCELLED;
   }
 }

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -12,7 +12,9 @@ public enum SuccessType {
   SUCCESS_INQUIRY_COURSES_DETAIL(HttpStatus.OK, "강의 상세 정보를 성공적으로 조회하였습니다."),
   SUCCESS_ENROLLMENT(HttpStatus.OK, "수강신청이 성공적으로 완료되었습니다."),
   SUCCESS_PAYMENT(HttpStatus.OK, "결제가 성공적으로 완료되었습니다."),
-  SUCCESS_INQUIRY_ENROLLMENTS(HttpStatus.OK, "내 수강 신청 목록을 성공적으로 조회하였습니다.");
+  SUCCESS_INQUIRY_ENROLLMENTS(HttpStatus.OK, "내 수강 신청 목록을 성공적으로 조회하였습니다."),
+  SUCCESS_CANCEL_ENROLLMENT(HttpStatus.OK, "신청한 수강을 성공적으로 취소하였습니다."),
+  ;
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/example/assignment/service/EnrollmentService.java
+++ b/src/main/java/com/example/assignment/service/EnrollmentService.java
@@ -9,4 +9,6 @@ public interface EnrollmentService {
   ResultResponse payEnroll(Long userId, Long enrollmentId);
 
   ResultResponse getEnroll(Long userId, int page);
+
+  ResultResponse cancelEnroll(Long userId, Long enrollmentId);
 }

--- a/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
@@ -70,7 +70,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
         .orElseThrow(() -> new GlobalException(FailedType.ENROLLMENT_NOT_FOUND));
 
-    if (!enrollment.getUser().getUserId().equals(userId)) {
+    if (enrollment.isNotOwnedBy(userId)) {
       throw new GlobalException(FailedType.ACCESS_DENIED);
     }
 
@@ -101,5 +101,29 @@ public class EnrollmentServiceImpl implements EnrollmentService {
 
     return new ResultResponse(SuccessType.SUCCESS_INQUIRY_ENROLLMENTS, enrollPageRes);
 
+  }
+
+  @Override
+  @Transactional
+  public ResultResponse cancelEnroll(Long userId, Long enrollmentId) {
+
+    Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
+        .orElseThrow(() -> new GlobalException(FailedType.ENROLLMENT_NOT_FOUND));
+
+    if (enrollment.isNotOwnedBy(userId)) {
+      throw new GlobalException(FailedType.ACCESS_DENIED);
+    }
+
+    if (enrollment.isCancelled()) {
+      throw new GlobalException(FailedType.ALREADY_CANCELLED);
+    }
+
+    Course course = courseRepository.findByIdWithLock(enrollment.getCourse().getCourseId())
+        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+
+    course.decreaseEnrollmentCnt();
+    enrollment.cancel();
+
+    return ResultResponse.of(SuccessType.SUCCESS_CANCEL_ENROLLMENT);
   }
 }


### PR DESCRIPTION
## 작업 내용
수강신청을 취소할 수 있는 API 를 구현
취소 시 정원을 복구하고, 정원이 마감(CLOSED)된 강의는 자동으로 모집 중(OPEN)으로 복귀하도록 처리

## 주요 변경사항

### 수강 취소 API 구현
- `DELETE /api/v1/enrollment/{userId}/{enrollmentId}` 엔드포인트 추가
- 검증 순서: 수강신청 존재 → 본인 확인 → 취소 여부 확인 → 정원 복구 → 상태 변경

### Course 엔티티 — 정원 감소 메서드 추가
- `decreaseEnrollmentCnt()` 구현
  - `enrollmentCnt` 가 0 이하일 경우 감소하지 않도록 방어 처리
  - `CLOSED` 상태에서 자리가 나면 자동으로 `OPEN` 으로 복귀

### Enrollment 엔티티 — 취소 관련 메서드 추가
- `isNotOwnedBy(Long userId)` : 본인 수강신청 여부 검증
- `cancel()` : 상태를 `CANCELLED` 로 전환

### `payEnroll()` 리팩토링
- 기존 `!enrollment.getUser().getUserId().equals(userId)` → `enrollment.isNotOwnedBy(userId)` 로 도메인 메서드 적용
- 동일한 검증 로직을 엔티티에 응집시켜 일관성 확보

### 응답 상수 추가
- `SUCCESS_CANCEL_ENROLLMENT` (수강 취소 완료)