### PR TITLE
[Feat] 과제 A - (강사) 강의 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/example/assignment/controller/CourseController.java
+++ b/src/main/java/com/example/assignment/controller/CourseController.java
@@ -2,6 +2,7 @@ package com.example.assignment.controller;
 
 import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.domain.dto.request.CourseReq;
+import com.example.assignment.domain.dto.request.CourseStatusReq;
 import com.example.assignment.domain.type.CourseStatus;
 import com.example.assignment.service.CourseService;
 import jakarta.validation.Valid;
@@ -55,10 +56,13 @@ public class CourseController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
-  @GetMapping("/{userId}/{courseId}")
-  public ResponseEntity<ResultResponse> updateCourseStatus(@PathVariable Long userId, @PathVariable Long courseId) {
+  @PatchMapping("/{userId}/{courseId}/status")
+  public ResponseEntity<ResultResponse> updateCourseStatus(
+      @PathVariable Long userId,
+      @PathVariable Long courseId,
+      @RequestBody @Valid CourseStatusReq courseStatusReq) {
 
-    ResultResponse response = courseService.updateCourseStatus(userId, courseId);
+    ResultResponse response = courseService.updateCourseStatus(userId, courseId, courseStatusReq);
     return new ResponseEntity<>(response, response.getStatus());
   }
 

--- a/src/main/java/com/example/assignment/controller/CourseController.java
+++ b/src/main/java/com/example/assignment/controller/CourseController.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -51,6 +52,13 @@ public class CourseController {
   public ResponseEntity<ResultResponse> getCourseDetail(@PathVariable Long courseId) {
 
     ResultResponse response = courseService.getCourseDetail(courseId);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+  @GetMapping("/{userId}/{courseId}")
+  public ResponseEntity<ResultResponse> updateCourseStatus(@PathVariable Long userId, @PathVariable Long courseId) {
+
+    ResultResponse response = courseService.updateCourseStatus(userId, courseId);
     return new ResponseEntity<>(response, response.getStatus());
   }
 

--- a/src/main/java/com/example/assignment/domain/dto/request/CourseStatusReq.java
+++ b/src/main/java/com/example/assignment/domain/dto/request/CourseStatusReq.java
@@ -1,0 +1,14 @@
+package com.example.assignment.domain.dto.request;
+
+import com.example.assignment.domain.type.CourseStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CourseStatusReq {
+
+  @NotNull(message = "변경할 강의 상태를 입력해주세요.")
+  private CourseStatus courseStatus;
+}

--- a/src/main/java/com/example/assignment/domain/dto/response/EnrollmentPageRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/EnrollmentPageRes.java
@@ -1,8 +1,6 @@
 package com.example.assignment.domain.dto.response;
 
-import com.example.assignment.domain.entity.Course;
 import com.example.assignment.domain.entity.Enrollment;
-import com.example.assignment.domain.type.EnrollmentStatus;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -98,15 +98,19 @@ public class Course extends BaseEntity {
     return !this.user.getUserId().equals(userId);
   }
 
+  public boolean isBefore() {
+    return this.endPeriodAt.isBefore(LocalDate.now());
+  }
+
+  public boolean isOpen() {
+    return this.courseStatus == CourseStatus.OPEN;
+  }
+
+  public boolean isClosed() {
+    return this.courseStatus == CourseStatus.CLOSED;
+  }
+
   public void openCourse() {
-    if (this.courseStatus == CourseStatus.OPEN) {
-      throw new GlobalException(FailedType.COURSE_ALREADY_OPEN);
-    }
-
-    if (this.courseStatus == CourseStatus.CLOSED) {
-      throw new GlobalException(FailedType.COURSE_ALREADY_CLOSED);
-    }
-
     this.courseStatus = CourseStatus.OPEN;
   }
 

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -2,8 +2,6 @@ package com.example.assignment.domain.entity;
 
 import com.example.assignment.domain.dto.request.CourseReq;
 import com.example.assignment.domain.type.CourseStatus;
-import com.example.assignment.domain.type.FailedType;
-import com.example.assignment.exception.GlobalException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -98,7 +98,7 @@ public class Course extends BaseEntity {
     return !this.user.getUserId().equals(userId);
   }
 
-  public boolean isBefore() {
+  public boolean isExpired() {
     return this.endPeriodAt.isBefore(LocalDate.now());
   }
 

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -114,4 +114,8 @@ public class Course extends BaseEntity {
     this.courseStatus = CourseStatus.OPEN;
   }
 
+  public void closeCourse() {
+    this.courseStatus = CourseStatus.CLOSED;
+  }
+
 }

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -2,6 +2,8 @@ package com.example.assignment.domain.entity;
 
 import com.example.assignment.domain.dto.request.CourseReq;
 import com.example.assignment.domain.type.CourseStatus;
+import com.example.assignment.domain.type.FailedType;
+import com.example.assignment.exception.GlobalException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -90,6 +92,22 @@ public class Course extends BaseEntity {
     if (this.courseStatus == CourseStatus.CLOSED && !this.isFull()) {
       this.courseStatus = CourseStatus.OPEN;
     }
+  }
+
+  public boolean isNotOwnedBy(Long userId) {
+    return !this.user.getUserId().equals(userId);
+  }
+
+  public void openCourse() {
+    if (this.courseStatus == CourseStatus.OPEN) {
+      throw new GlobalException(FailedType.COURSE_ALREADY_OPEN);
+    }
+
+    if (this.courseStatus == CourseStatus.CLOSED) {
+      throw new GlobalException(FailedType.COURSE_ALREADY_CLOSED);
+    }
+
+    this.courseStatus = CourseStatus.OPEN;
   }
 
 }

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -17,6 +17,8 @@ public enum FailedType {
   ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 수강신청 내역입니다."),
   ALREADY_PAID(HttpStatus.BAD_REQUEST, "이미 결제가 완료된 수강신청입니다."),
   ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 수강신청입니다."),
+  COURSE_ALREADY_OPEN(HttpStatus.BAD_REQUEST, "이미 모집 중인 강의입니다."),
+  COURSE_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "이미 마감된 강의입니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -20,6 +20,7 @@ public enum FailedType {
   COURSE_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "수강 기간이 만료된 강의입니다."),
   COURSE_ALREADY_OPEN(HttpStatus.BAD_REQUEST, "이미 모집 중인 강의입니다."),
   COURSE_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "이미 마감된 강의입니다."),
+  INVALID_COURSE_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "해당 상태로는 변경할 수 없습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -17,6 +17,7 @@ public enum FailedType {
   ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 수강신청 내역입니다."),
   ALREADY_PAID(HttpStatus.BAD_REQUEST, "이미 결제가 완료된 수강신청입니다."),
   ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 수강신청입니다."),
+  COURSE_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "수강 기간이 만료된 강의입니다."),
   COURSE_ALREADY_OPEN(HttpStatus.BAD_REQUEST, "이미 모집 중인 강의입니다."),
   COURSE_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "이미 마감된 강의입니다."),
   ;

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -14,6 +14,7 @@ public enum SuccessType {
   SUCCESS_PAYMENT(HttpStatus.OK, "결제가 성공적으로 완료되었습니다."),
   SUCCESS_INQUIRY_ENROLLMENTS(HttpStatus.OK, "내 수강 신청 목록을 성공적으로 조회하였습니다."),
   SUCCESS_CANCEL_ENROLLMENT(HttpStatus.OK, "신청한 수강을 성공적으로 취소하였습니다."),
+  SUCCESS_UPDATE_COURSE_STATUS(HttpStatus.OK, "강의 상태를 성공적으로 변경하였습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/service/CourseService.java
+++ b/src/main/java/com/example/assignment/service/CourseService.java
@@ -2,6 +2,7 @@ package com.example.assignment.service;
 
 import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.domain.dto.request.CourseReq;
+import com.example.assignment.domain.dto.request.CourseStatusReq;
 import com.example.assignment.domain.type.CourseStatus;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
@@ -15,5 +16,5 @@ public interface CourseService {
 
   ResultResponse getCourseDetail(Long courseId);
 
-  ResultResponse updateCourseStatus(Long userId, Long courseId);
+  ResultResponse updateCourseStatus(Long userId, Long courseId, CourseStatusReq courseStatusReq);
 }

--- a/src/main/java/com/example/assignment/service/CourseService.java
+++ b/src/main/java/com/example/assignment/service/CourseService.java
@@ -14,4 +14,6 @@ public interface CourseService {
       LocalDate startPeriodAt, LocalDate endPeriodAt, CourseStatus courseStatus, int page);
 
   ResultResponse getCourseDetail(Long courseId);
+
+  ResultResponse updateCourseStatus(Long userId, Long courseId);
 }

--- a/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
@@ -98,14 +98,14 @@ public class CourseServiceImpl implements CourseService {
       throw new GlobalException(FailedType.ACCESS_DENIED);
     }
 
-    Course course = courseRepository.findById(courseId)
+    Course course = courseRepository.findByIdWithLock(courseId)
         .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
 
     if (course.isNotOwnedBy(userId)) {
       throw new GlobalException(FailedType.ACCESS_DENIED);
     }
 
-    if(course.isBefore()) {
+    if(course.isExpired()) {
       throw new GlobalException(FailedType.COURSE_PERIOD_EXPIRED);
     }
 
@@ -114,10 +114,12 @@ public class CourseServiceImpl implements CourseService {
       if (course.isClosed()) throw new GlobalException(FailedType.COURSE_ALREADY_CLOSED);
       course.openCourse();
 
-    }else if(courseStatusReq.getCourseStatus() == CourseStatus.CLOSED) {
+    } else if(courseStatusReq.getCourseStatus() == CourseStatus.CLOSED) {
       if (course.isClosed()) throw new GlobalException(FailedType.COURSE_ALREADY_CLOSED);
 
       course.closeCourse();
+    } else {
+      throw new GlobalException(FailedType.INVALID_COURSE_STATUS_TRANSITION);
     }
 
     return ResultResponse.of(SuccessType.SUCCESS_UPDATE_COURSE_STATUS);

--- a/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
@@ -85,4 +85,26 @@ public class CourseServiceImpl implements CourseService {
     CourseRes courseRes = CourseRes.toCourseRes(course);
     return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSES_DETAIL, courseRes);
   }
+
+  @Override
+  @Transactional
+  public ResultResponse updateCourseStatus(Long userId, Long courseId) {
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+
+    if (user.isStudent()) {
+      throw new GlobalException(FailedType.ACCESS_DENIED);
+    }
+
+    Course course = courseRepository.findById(courseId)
+        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+
+    if (course.isNotOwnedBy(userId)) {
+      throw new GlobalException(FailedType.ACCESS_DENIED);
+    }
+
+    course.openCourse();
+    return ResultResponse.of(SuccessType.SUCCESS_UPDATE_COURSE_STATUS);
+  }
 }

--- a/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
@@ -104,7 +104,20 @@ public class CourseServiceImpl implements CourseService {
       throw new GlobalException(FailedType.ACCESS_DENIED);
     }
 
+    if(course.isBefore()) {
+      throw new GlobalException(FailedType.COURSE_PERIOD_EXPIRED);
+    }
+
+    if(course.isOpen()) {
+      throw new GlobalException(FailedType.COURSE_ALREADY_OPEN);
+    }
+
+    if (course.isClosed()) {
+      throw new GlobalException(FailedType.COURSE_ALREADY_CLOSED);
+    }
+
     course.openCourse();
+
     return ResultResponse.of(SuccessType.SUCCESS_UPDATE_COURSE_STATUS);
   }
 }

--- a/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.assignment.service.impl;
 import com.example.assignment.domain.dto.PageResponse;
 import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.domain.dto.request.CourseReq;
+import com.example.assignment.domain.dto.request.CourseStatusReq;
 import com.example.assignment.domain.dto.response.CoursePageRes;
 import com.example.assignment.domain.dto.response.CourseRes;
 import com.example.assignment.domain.entity.Course;
@@ -88,7 +89,7 @@ public class CourseServiceImpl implements CourseService {
 
   @Override
   @Transactional
-  public ResultResponse updateCourseStatus(Long userId, Long courseId) {
+  public ResultResponse updateCourseStatus(Long userId, Long courseId, CourseStatusReq courseStatusReq) {
 
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
@@ -108,15 +109,16 @@ public class CourseServiceImpl implements CourseService {
       throw new GlobalException(FailedType.COURSE_PERIOD_EXPIRED);
     }
 
-    if(course.isOpen()) {
-      throw new GlobalException(FailedType.COURSE_ALREADY_OPEN);
-    }
+    if(courseStatusReq.getCourseStatus() == CourseStatus.OPEN) {
+      if (course.isOpen()) throw new GlobalException(FailedType.COURSE_ALREADY_OPEN);
+      if (course.isClosed()) throw new GlobalException(FailedType.COURSE_ALREADY_CLOSED);
+      course.openCourse();
 
-    if (course.isClosed()) {
-      throw new GlobalException(FailedType.COURSE_ALREADY_CLOSED);
-    }
+    }else if(courseStatusReq.getCourseStatus() == CourseStatus.CLOSED) {
+      if (course.isClosed()) throw new GlobalException(FailedType.COURSE_ALREADY_CLOSED);
 
-    course.openCourse();
+      course.closeCourse();
+    }
 
     return ResultResponse.of(SuccessType.SUCCESS_UPDATE_COURSE_STATUS);
   }


### PR DESCRIPTION
## 작업 내용
> 강사가 강의 상태를 수동으로 변경할 수 있는 API 구현 
> 조기 마감 시 발생할 수 있는 동시성 문제를 비관적 락으로 처리하고, 엔티티 순수성 유지를 위해 예외 처리는 서비스 레이어에서 담당하도록 설계

## 주요 변경사항

### 강의 상태 변경 API 구현
- `PATCH /api/v1/course/{userId}/{courseId}/status` 엔드포인트 추가
- 검증 순서: 사용자 존재 → 권한(강사인지) → 강의 존재 → 소유권 → 기간 만료 → 상태 전환 규칙

### Course 엔티티 도메인 메서드 추가
- `isNotOwnedBy(Long userId)` : 본인 강의 여부 검증
- `isExpired()` : 수강 기간 만료 여부 (`isBefore()` 에서 네이밍 변경)
- `isOpen()`, `isClosed()` : 상태 판별
- `openCourse()`, `closeCourse()` : 상태 전환 (예외 없이 순수하게 상태만 변경)

### 상태 전환 규칙

| 현재 상태 | 요청 상태 | 결과 |
|---|---|---|
| DRAFT | OPEN | 전환 |
| DRAFT | CLOSED | 전환 (바로 마감 허용) |
| OPEN | CLOSED | 전환 |
| OPEN | OPEN | `COURSE_ALREADY_OPEN` |
| CLOSED | OPEN | `COURSE_ALREADY_CLOSED` |
| CLOSED | CLOSED | `COURSE_ALREADY_CLOSED` |
| 모든 상태 | DRAFT | `INVALID_COURSE_STATUS_TRANSITION` |

--- 
### 조기 마감 시 비관적 락 적용
강사의 수동 마감과 학생의 수강신청이 동시에 발생하면, 이미 마감된 강의에 신청이 들어오는 경합이 생길 수 있음. 
수강신청과 동일하게 `findByIdWithLock()` 을 적용해 두 트랜잭션이 순차 처리되도록 함.

### DRAFT → CLOSED 허용
모집을 시작하지 않고 바로 마감하는 케이스를 허용함. 강사가 사정에 따라 강의를 즉시 닫을 수 있도록 유연한 정책으로 설계