### PR TITLE
[Feat] 과제 A - (강사) 강의별 수강생 목록 조회

### DIFF
--- a/src/main/java/com/example/assignment/controller/CourseController.java
+++ b/src/main/java/com/example/assignment/controller/CourseController.java
@@ -66,4 +66,15 @@ public class CourseController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  @GetMapping("/{userId}/{courseId}")
+  public ResponseEntity<ResultResponse> getCourseEnrollments(
+      @PathVariable Long userId,
+      @PathVariable Long courseId,
+      @RequestParam(defaultValue = "1") int page
+  ) {
+
+    ResultResponse response = courseService.getCourseEnrollments(userId, courseId, page);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
 }

--- a/src/main/java/com/example/assignment/controller/CourseController.java
+++ b/src/main/java/com/example/assignment/controller/CourseController.java
@@ -66,7 +66,7 @@ public class CourseController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
-  @GetMapping("/{userId}/{courseId}")
+  @GetMapping("/{userId}/{courseId}/enrollments")
   public ResponseEntity<ResultResponse> getCourseEnrollments(
       @PathVariable Long userId,
       @PathVariable Long courseId,

--- a/src/main/java/com/example/assignment/domain/dto/response/CourseEnrollmentRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/CourseEnrollmentRes.java
@@ -1,0 +1,35 @@
+package com.example.assignment.domain.dto.response;
+
+import com.example.assignment.domain.dto.PageResponse;
+import com.example.assignment.domain.entity.Course;
+import com.example.assignment.domain.entity.Enrollment;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CourseEnrollmentRes {
+
+  private Long courseId;
+
+  private String title;
+
+  private String creatorName;
+
+  private PageResponse<EnrollmentStudentRes> pageResponse;
+
+  public static CourseEnrollmentRes of(Course course, List<Enrollment> enrollments, int page) {
+    List<EnrollmentStudentRes> studentList = EnrollmentStudentRes.toList(enrollments);
+    PageResponse<EnrollmentStudentRes> pageResponse = PageResponse.pagination(studentList, page);
+
+    return new CourseEnrollmentRes(
+        course.getCourseId(),
+        course.getTitle(),
+        course.getUser().getName(),
+        pageResponse
+    );
+  }
+}

--- a/src/main/java/com/example/assignment/domain/dto/response/CoursePageRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/CoursePageRes.java
@@ -26,7 +26,7 @@ public class CoursePageRes {
 
   private LocalDate endPeriodAt;
 
-  public static List<CoursePageRes> toCourseResList(List<Course> list) {
+  public static List<CoursePageRes> toList(List<Course> list) {
     return list.stream()
         .map(course ->
             new CoursePageRes(

--- a/src/main/java/com/example/assignment/domain/dto/response/CourseRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/CourseRes.java
@@ -30,7 +30,7 @@ public class CourseRes {
 
   private String enrollmentRatio;
 
-  public static CourseRes toCourseRes(Course course) {
+  public static CourseRes of(Course course) {
     return new CourseRes(
         course.getCourseId(),
         course.getTitle(),

--- a/src/main/java/com/example/assignment/domain/dto/response/EnrollmentPageRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/EnrollmentPageRes.java
@@ -32,7 +32,7 @@ public class EnrollmentPageRes {
 
   private String enrollmentStatus;
 
-  public static List<EnrollmentPageRes> toEnrollmentPageList(List<Enrollment> list) {
+  public static List<EnrollmentPageRes> toList(List<Enrollment> list) {
     return list.stream()
         .map(enrollment ->
             new EnrollmentPageRes(

--- a/src/main/java/com/example/assignment/domain/dto/response/EnrollmentStudentRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/EnrollmentStudentRes.java
@@ -1,0 +1,28 @@
+package com.example.assignment.domain.dto.response;
+
+
+import com.example.assignment.domain.entity.Enrollment;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EnrollmentStudentRes {
+
+  private String studentName;
+
+  private String enrollmentStatus;
+
+  public static List<EnrollmentStudentRes> toList(List<Enrollment> list) {
+    return list.stream()
+        .map(enrollment ->
+            new EnrollmentStudentRes(
+                enrollment.getUser().getName(),
+                enrollment.getEnrollmentStatus().getValue()
+            ))
+        .toList();
+  }
+}

--- a/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
@@ -22,4 +22,12 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     ORDER BY e.createdAt DESC
     """)
   List<Enrollment> findAllByUserWithCourse(@Param("user") User user);
+
+  @Query("""
+    SELECT e FROM Enrollment e
+    JOIN FETCH e.user
+    WHERE e.course = :course
+    ORDER BY e.createdAt DESC
+    """)
+  List<Enrollment> findAllByCourseWithUser(@Param("course") Course course);
 }

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -15,6 +15,7 @@ public enum SuccessType {
   SUCCESS_INQUIRY_ENROLLMENTS(HttpStatus.OK, "내 수강 신청 목록을 성공적으로 조회하였습니다."),
   SUCCESS_CANCEL_ENROLLMENT(HttpStatus.OK, "신청한 수강을 성공적으로 취소하였습니다."),
   SUCCESS_UPDATE_COURSE_STATUS(HttpStatus.OK, "강의 상태를 성공적으로 변경하였습니다."),
+  SUCCESS_INQUIRY_COURSE_ENROLLMENTS(HttpStatus.OK, "수강생 목록을 조회했습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/service/CourseService.java
+++ b/src/main/java/com/example/assignment/service/CourseService.java
@@ -17,4 +17,6 @@ public interface CourseService {
   ResultResponse getCourseDetail(Long courseId);
 
   ResultResponse updateCourseStatus(Long userId, Long courseId, CourseStatusReq courseStatusReq);
+
+  ResultResponse getCourseEnrollments(Long userId, Long courseId, int page);
 }

--- a/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
@@ -4,11 +4,14 @@ import com.example.assignment.domain.dto.PageResponse;
 import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.domain.dto.request.CourseReq;
 import com.example.assignment.domain.dto.request.CourseStatusReq;
+import com.example.assignment.domain.dto.response.CourseEnrollmentRes;
 import com.example.assignment.domain.dto.response.CoursePageRes;
 import com.example.assignment.domain.dto.response.CourseRes;
 import com.example.assignment.domain.entity.Course;
+import com.example.assignment.domain.entity.Enrollment;
 import com.example.assignment.domain.entity.User;
 import com.example.assignment.domain.repository.CourseRepository;
+import com.example.assignment.domain.repository.EnrollmentRepository;
 import com.example.assignment.domain.repository.UserRepository;
 import com.example.assignment.domain.repository.querydsl.CourseQueryRepository;
 import com.example.assignment.domain.type.CourseStatus;
@@ -29,6 +32,7 @@ public class CourseServiceImpl implements CourseService {
   private final UserRepository userRepository;
   private final CourseRepository courseRepository;
   private final CourseQueryRepository courseQueryRepository;
+  private final EnrollmentRepository enrollmentRepository;
 
   @Override
   @Transactional
@@ -70,7 +74,7 @@ public class CourseServiceImpl implements CourseService {
     List<Course> courses = courseQueryRepository.searchCourses(creatorName, title, minAmount,
         maxAmount, startPeriodAt, endPeriodAt, courseStatus);
 
-    List<CoursePageRes> courseRes = CoursePageRes.toCourseResList(courses);
+    List<CoursePageRes> courseRes = CoursePageRes.toList(courses);
 
     PageResponse<CoursePageRes> pageResponse = PageResponse.pagination(courseRes, page);
     return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSES, pageResponse);
@@ -83,7 +87,7 @@ public class CourseServiceImpl implements CourseService {
     Course course = courseRepository.findById(courseId)
         .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
 
-    CourseRes courseRes = CourseRes.toCourseRes(course);
+    CourseRes courseRes = CourseRes.of(course);
     return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSES_DETAIL, courseRes);
   }
 
@@ -123,5 +127,28 @@ public class CourseServiceImpl implements CourseService {
     }
 
     return ResultResponse.of(SuccessType.SUCCESS_UPDATE_COURSE_STATUS);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public ResultResponse getCourseEnrollments(Long userId, Long courseId, int page) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+
+    if (user.isStudent()) {
+      throw new GlobalException(FailedType.ACCESS_DENIED);
+    }
+
+    Course course = courseRepository.findById(courseId)
+        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+
+    if (course.isNotOwnedBy(userId)) {
+      throw new GlobalException(FailedType.ACCESS_DENIED);
+    }
+
+    List<Enrollment> enrollments = enrollmentRepository.findAllByCourseWithUser(course);
+    CourseEnrollmentRes response = CourseEnrollmentRes.of(course, enrollments, page);
+
+    return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSE_ENROLLMENTS, response);
   }
 }

--- a/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
@@ -95,7 +95,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
         .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
 
     List<Enrollment> enrollments = enrollmentRepository.findAllByUserWithCourse(user);
-    List<EnrollmentPageRes> enrollmentPageRes = EnrollmentPageRes.toEnrollmentPageList(enrollments);
+    List<EnrollmentPageRes> enrollmentPageRes = EnrollmentPageRes.toList(enrollments);
 
     PageResponse<EnrollmentPageRes> enrollPageRes = PageResponse.pagination(enrollmentPageRes, page);
 


### PR DESCRIPTION
## 작업 내용
> 강사가 본인 강의의 수강생 목록을 조회할 수 있는 API 를 구현
> N+1 문제 방지를 위해 `fetchJoin` 을 적용하고, 변환 로직을 DTO 내부로 응집시켜 서비스 코드를 간결하게 유지

## 주요 변경사항

### 강의별 수강생 목록 조회 API 구현
- `GET /api/v1/course/{userId}/{courseId}/enrollments` 엔드포인트 추가
- 크리에이터 전용 — 학생 접근 및 타인 강의 접근 차단
- 검증 순서: 사용자 존재 → 권한(강사인지) → 강의 존재 → 소유권 확인
- 페이지네이션 적용 (기본값 1페이지)

### 응답 DTO 추가
- `CourseEnrollmentRes` — 강의 정보 + 수강생 목록을 담는 최상위 DTO
  - 변환 로직(`of()`)을 DTO 내부로 응집시켜 서비스 코드 단순화
- `EnrollmentStudentRes` — 수강생 이름, 신청 상태를 담는 리스트 항목 DTO

### N+1 문제 방지를 위한 fetchJoin 적용
- `EnrollmentRepository.findAllByCourseWithUser()` 추가
- `JOIN FETCH e.user` 로 User 를 한 번에 조회
- 최신순 정렬(`ORDER BY e.createdAt DESC`) 기본 적용

### DTO 정적 팩토리 메서드 네이밍 통일 (리팩토링)
- `toCourseResList()` → `toList()`
- `toCourseRes()` → `of()`
- `toEnrollmentPageList()` → `toList()`
- 프로젝트 전반의 메서드 네이밍 일관성 확보
---
### 변환 로직을 DTO 내부로 응집
`CourseEnrollmentRes.of(course, enrollments, page)` 한 줄로 리스트 변환 → 페이징 → DTO 조립까지 처리하도록 설계함. 서비스가 변환 과정을 알 필요 없이 흐름 제어에만 집중할 수 있음.