### PR TITLE
[Refactor] 과제 A - 수강 취소 기간 제한 로직 추가

### DIFF
--- a/src/main/java/com/example/assignment/controller/EnrollmentController.java
+++ b/src/main/java/com/example/assignment/controller/EnrollmentController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+
 @RequestMapping("/api/v1/enrollment")
 @RequiredArgsConstructor
 public class EnrollmentController {
@@ -21,28 +22,32 @@ public class EnrollmentController {
   private final EnrollmentService enrollmentService;
 
   @PostMapping("/{userId}/{courseId}")
-  public ResponseEntity<ResultResponse> enroll(@PathVariable Long userId, @PathVariable Long courseId) {
+  public ResponseEntity<ResultResponse> enroll(@PathVariable Long userId,
+      @PathVariable Long courseId) {
 
     ResultResponse response = enrollmentService.enroll(userId, courseId);
     return new ResponseEntity<>(response, response.getStatus());
   }
 
   @PatchMapping("/{userId}/{enrollmentId}/pay")
-  public ResponseEntity<ResultResponse> payEnroll(@PathVariable Long userId, @PathVariable Long enrollmentId) {
+  public ResponseEntity<ResultResponse> payEnroll(@PathVariable Long userId,
+      @PathVariable Long enrollmentId) {
 
     ResultResponse response = enrollmentService.payEnroll(userId, enrollmentId);
     return new ResponseEntity<>(response, response.getStatus());
   }
 
   @GetMapping("/{userId}")
-  public ResponseEntity<ResultResponse> getEnroll(@PathVariable Long userId, @RequestParam(defaultValue = "1") int page ) {
+  public ResponseEntity<ResultResponse> getEnroll(@PathVariable Long userId,
+      @RequestParam(defaultValue = "1") int page) {
 
     ResultResponse response = enrollmentService.getEnroll(userId, page);
     return new ResponseEntity<>(response, response.getStatus());
   }
 
   @DeleteMapping("/{userId}/{enrollmentId}")
-  public ResponseEntity<ResultResponse> cancelled(@PathVariable Long userId, @PathVariable Long enrollmentId) {
+  public ResponseEntity<ResultResponse> cancelled(@PathVariable Long userId,
+      @PathVariable Long enrollmentId) {
 
     ResultResponse response = enrollmentService.cancelEnroll(userId, enrollmentId);
     return new ResponseEntity<>(response, response.getStatus());

--- a/src/main/java/com/example/assignment/domain/entity/Enrollment.java
+++ b/src/main/java/com/example/assignment/domain/entity/Enrollment.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -63,5 +64,17 @@ public class Enrollment extends BaseEntity {
 
   public void cancel() {
     this.enrollmentStatus = EnrollmentStatus.CANCELLED;
+  }
+
+  public boolean isCancellable() {
+    if (this.enrollmentStatus == EnrollmentStatus.PENDING) {
+      return true;
+    }
+    if (this.enrollmentStatus == EnrollmentStatus.CONFIRMED) {
+      return this.getUpdatedAt()
+          .plusDays(7)
+          .isAfter(LocalDateTime.now());
+    }
+    return false;
   }
 }

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -21,6 +21,7 @@ public enum FailedType {
   COURSE_ALREADY_OPEN(HttpStatus.BAD_REQUEST, "이미 모집 중인 강의입니다."),
   COURSE_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "이미 마감된 강의입니다."),
   INVALID_COURSE_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "해당 상태로는 변경할 수 없습니다."),
+  CANCEL_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "취소 가능 기간(결제 후 7일)이 지났습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
@@ -118,7 +118,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
       throw new GlobalException(FailedType.ALREADY_CANCELLED);
     }
 
-    if(enrollment.isCancellable()) {
+    if(!enrollment.isCancellable()) {
       throw new GlobalException(FailedType.CANCEL_PERIOD_EXPIRED);
     }
 

--- a/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
@@ -118,6 +118,10 @@ public class EnrollmentServiceImpl implements EnrollmentService {
       throw new GlobalException(FailedType.ALREADY_CANCELLED);
     }
 
+    if(enrollment.isCancellable()) {
+      throw new GlobalException(FailedType.CANCEL_PERIOD_EXPIRED);
+    }
+
     Course course = courseRepository.findByIdWithLock(enrollment.getCourse().getCourseId())
         .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
 


### PR DESCRIPTION
## 작업 내용
> 결제 완료 후 7일 이내에만 수강 취소가 가능하도록 취소 기간 제한 로직 추가

## 주요 변경사항

### `Enrollment.isCancellable()` 도메인 메서드 추가

```java
public boolean isCancellable() {
    // PENDING 은 결제 전이라 언제든 취소 가능
    if (this.enrollmentStatus == EnrollmentStatus.PENDING) {
        return true;
    }
    // CONFIRMED 는 결제 완료(updatedAt) 기준 7일 이내만 취소 가능
    if (this.enrollmentStatus == EnrollmentStatus.CONFIRMED) {
        return this.getUpdatedAt().plusDays(7).isAfter(LocalDateTime.now());
    }
    return false;
}
```

### `cancelEnroll()` 에 취소 기간 검증 추가

```java
if (!enrollment.isCancellable()) {
    throw new GlobalException(FailedType.CANCEL_PERIOD_EXPIRED);
}
```

---
### 취소 기간 기준을 `updatedAt` 으로 설정한 이유
confirm() 호출 시 JPA Auditing 이 `updatedAt` 을 자동으로 갱신하므로**결제 완료 시점 = `updatedAt`** 으로 볼 수 있음.
현재 `Enrollment.updatedAt` 을 갱신하는 지점은 `confirm()` 과 `cancel()` 뿐이며,`cancel()` 호출 후에는 `isCancelled()` 로 재접근이 차단되므로 기준 변질 가능성이 없음.

### 상태별 취소 정책

| 상태 | 취소 가능 여부 |
|---|---|
| PENDING | 언제든 가능 (결제 전) |
| CONFIRMED | 결제 후 7일 이내만 가능 |
| CANCELLED | 불가 (이미 취소됨) |

### 검증 순서

```
수강신청 존재 확인
    ↓
본인 확인
    ↓
이미 취소 여부 (ALREADY_CANCELLED)
    ↓
취소 가능 기간 여부 (CANCEL_PERIOD_EXPIRED) ← 추가
    ↓
락 획득 + 정원 복구 + 상태 변경