### PR TITLE
[Refactor] 과제 A - 수강 신청시 대기열 로직 추가

### DIFF
--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -49,6 +49,8 @@ public class Course extends BaseEntity {
 
   private Long enrollmentCnt;
 
+  // =================== 정적 팩토리 메서드 ===================
+
   public static Course toEntity(CourseReq courseReq, User user) {
     return Course.builder()
         .title(courseReq.getTitle())
@@ -63,50 +65,57 @@ public class Course extends BaseEntity {
         .build();
   }
 
-  public boolean isFull() {
-    return enrollmentCnt >= personnel;
-  }
-
-  public void increaseEnrollmentCnt() {
-    this.enrollmentCnt++;
-
-    // 정원이 꽉 찼으면 자동으로 CLOSED 로 변경
-    if (this.isFull()) {
-      this.courseStatus = CourseStatus.CLOSED;
-    }
-  }
+  // =================== 상태 판별 ===================
 
   public boolean isNotAvailable() {
-    return courseStatus == CourseStatus.DRAFT
-        || courseStatus == CourseStatus.CLOSED;
+    return courseStatus == CourseStatus.DRAFT;
   }
 
-  public void decreaseEnrollmentCnt() {
-    if (this.enrollmentCnt > 0) {
-      this.enrollmentCnt--;
-    }
+  public boolean isOpen() {
+    return courseStatus == CourseStatus.OPEN;
+  }
 
-    // CLOSED 상태였는데 자리가 나면 자동으로 OPEN 복귀
-    if (this.courseStatus == CourseStatus.CLOSED && !this.isFull()) {
-      this.courseStatus = CourseStatus.OPEN;
-    }
+  public boolean isClosed() {
+    return courseStatus == CourseStatus.CLOSED;
   }
 
   public boolean isNotOwnedBy(Long userId) {
     return !this.user.getUserId().equals(userId);
   }
 
+  // =================== 기간 판별 ===================
+
+  public boolean isStarted() {
+    return this.startPeriodAt.isBefore(LocalDate.now());
+  }
+
   public boolean isExpired() {
     return this.endPeriodAt.isBefore(LocalDate.now());
   }
 
-  public boolean isOpen() {
-    return this.courseStatus == CourseStatus.OPEN;
+  // =================== 정원 관리 ===================
+
+  public boolean isFull() {
+    return enrollmentCnt >= personnel;
   }
 
-  public boolean isClosed() {
-    return this.courseStatus == CourseStatus.CLOSED;
+  public void increaseEnrollmentCnt() {
+    this.enrollmentCnt++;
+    if (this.isFull()) {
+      this.courseStatus = CourseStatus.CLOSED;
+    }
   }
+
+  public void decreaseEnrollmentCnt() {
+    if (this.enrollmentCnt > 0) {
+      this.enrollmentCnt--;
+    }
+    if (this.courseStatus == CourseStatus.CLOSED && !this.isFull()) {
+      this.courseStatus = CourseStatus.OPEN;
+    }
+  }
+
+  // =================== 상태 변경 ===================
 
   public void openCourse() {
     this.courseStatus = CourseStatus.OPEN;
@@ -115,5 +124,4 @@ public class Course extends BaseEntity {
   public void closeCourse() {
     this.courseStatus = CourseStatus.CLOSED;
   }
-
 }

--- a/src/main/java/com/example/assignment/domain/entity/Enrollment.java
+++ b/src/main/java/com/example/assignment/domain/entity/Enrollment.java
@@ -38,6 +38,8 @@ public class Enrollment extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private EnrollmentStatus enrollmentStatus;
 
+  // =================== 정적 팩토리 메서드 ===================
+
   public static Enrollment toEntity(Course course, User user) {
     return Enrollment.builder()
         .course(course)
@@ -45,6 +47,16 @@ public class Enrollment extends BaseEntity {
         .enrollmentStatus(EnrollmentStatus.PENDING)
         .build();
   }
+
+  public static Enrollment toWaitlistEntity(Course course, User user) {
+    return Enrollment.builder()
+        .course(course)
+        .user(user)
+        .enrollmentStatus(EnrollmentStatus.WAITLISTED)
+        .build();
+  }
+
+  // =================== 상태 판별 ===================
 
   public boolean isNotOwnedBy(Long userId) {
     return !this.user.getUserId().equals(userId);
@@ -58,16 +70,13 @@ public class Enrollment extends BaseEntity {
     return enrollmentStatus == EnrollmentStatus.CANCELLED;
   }
 
-  public void confirm() {
-    this.enrollmentStatus = EnrollmentStatus.CONFIRMED;
-  }
-
-  public void cancel() {
-    this.enrollmentStatus = EnrollmentStatus.CANCELLED;
+  public boolean isWaitlisted() {
+    return enrollmentStatus == EnrollmentStatus.WAITLISTED;
   }
 
   public boolean isCancellable() {
-    if (this.enrollmentStatus == EnrollmentStatus.PENDING) {
+    if (this.enrollmentStatus == EnrollmentStatus.PENDING
+        || this.enrollmentStatus == EnrollmentStatus.WAITLISTED) {
       return true;
     }
     if (this.enrollmentStatus == EnrollmentStatus.CONFIRMED) {
@@ -76,5 +85,19 @@ public class Enrollment extends BaseEntity {
           .isAfter(LocalDateTime.now());
     }
     return false;
+  }
+
+  // =================== 상태 변경 ===================
+
+  public void confirm() {
+    this.enrollmentStatus = EnrollmentStatus.CONFIRMED;
+  }
+
+  public void cancel() {
+    this.enrollmentStatus = EnrollmentStatus.CANCELLED;
+  }
+
+  public void promote() {
+    this.enrollmentStatus = EnrollmentStatus.PENDING;
   }
 }

--- a/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
@@ -5,6 +5,7 @@ import com.example.assignment.domain.entity.Enrollment;
 import com.example.assignment.domain.entity.User;
 import com.example.assignment.domain.type.EnrollmentStatus;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -30,4 +31,13 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     ORDER BY e.createdAt DESC
     """)
   List<Enrollment> findAllByCourseWithUser(@Param("course") Course course);
+
+  @Query("""
+    SELECT e FROM Enrollment e
+    WHERE e.course = :course
+      AND e.enrollmentStatus = 'WAITLISTED'
+    ORDER BY e.createdAt ASC
+    LIMIT 1
+    """)
+  Optional<Enrollment> findFirstWaitlistedByCourse(@Param("course") Course course);
 }

--- a/src/main/java/com/example/assignment/domain/type/EnrollmentStatus.java
+++ b/src/main/java/com/example/assignment/domain/type/EnrollmentStatus.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum EnrollmentStatus {
   PENDING("신청완료, 결제대기"),
   CONFIRMED("결제완료, 수강 확정"),
-  CANCELLED("수강 취소");
+  CANCELLED("수강 취소"),
+  WAITLISTED("대기중");
 
   private final String value;
 

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -22,6 +22,7 @@ public enum FailedType {
   COURSE_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "이미 마감된 강의입니다."),
   INVALID_COURSE_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "해당 상태로는 변경할 수 없습니다."),
   CANCEL_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "취소 가능 기간(결제 후 7일)이 지났습니다."),
+  COURSE_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 시작된 강의는 신청할 수 없습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -16,6 +16,7 @@ public enum SuccessType {
   SUCCESS_CANCEL_ENROLLMENT(HttpStatus.OK, "신청한 수강을 성공적으로 취소하였습니다."),
   SUCCESS_UPDATE_COURSE_STATUS(HttpStatus.OK, "강의 상태를 성공적으로 변경하였습니다."),
   SUCCESS_INQUIRY_COURSE_ENROLLMENTS(HttpStatus.OK, "수강생 목록을 조회했습니다."),
+  SUCCESS_WAITLISTED(HttpStatus.OK, "정원이 마감되어 대기 신청이 되었습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
@@ -27,6 +27,8 @@ public class EnrollmentServiceImpl implements EnrollmentService {
   private final CourseRepository courseRepository;
   private final UserRepository userRepository;
 
+  // =================== 수강 신청 ===================
+
   @Override
   @Transactional
   public ResultResponse enroll(Long userId, Long courseId) {
@@ -45,23 +47,29 @@ public class EnrollmentServiceImpl implements EnrollmentService {
       throw new GlobalException(FailedType.COURSE_NOT_AVAILABLE);
     }
 
-    if (course.isFull()) {
-      throw new GlobalException(FailedType.COURSE_IS_FULL);
+    if (enrollmentRepository.existsByCourseAndUserAndEnrollmentStatusNot(
+        course, user, EnrollmentStatus.CANCELLED)) {
+      throw new GlobalException(FailedType.ALREADY_ENROLLED);
     }
 
-    if (enrollmentRepository.existsByCourseAndUserAndEnrollmentStatusNot(course, user, EnrollmentStatus.CANCELLED)) {
+    if (course.isStarted()) {
+      throw new GlobalException(FailedType.COURSE_ALREADY_STARTED);
+    }
 
-      throw new GlobalException(FailedType.ALREADY_ENROLLED);
+    if (course.isFull()) {
+      Enrollment waitlist = Enrollment.toWaitlistEntity(course, user);
+      enrollmentRepository.save(waitlist);
+      return ResultResponse.of(SuccessType.SUCCESS_WAITLISTED);
     }
 
     Enrollment enrollment = Enrollment.toEntity(course, user);
     enrollmentRepository.save(enrollment);
-
     course.increaseEnrollmentCnt();
 
     return ResultResponse.of(SuccessType.SUCCESS_ENROLLMENT);
   }
 
+  // =================== 결제 ===================
 
   @Override
   @Transactional
@@ -87,6 +95,8 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     return ResultResponse.of(SuccessType.SUCCESS_PAYMENT);
   }
 
+  // =================== 조회 ===================
+
   @Override
   @Transactional(readOnly = true)
   public ResultResponse getEnroll(Long userId, int page) {
@@ -96,12 +106,12 @@ public class EnrollmentServiceImpl implements EnrollmentService {
 
     List<Enrollment> enrollments = enrollmentRepository.findAllByUserWithCourse(user);
     List<EnrollmentPageRes> enrollmentPageRes = EnrollmentPageRes.toList(enrollments);
-
     PageResponse<EnrollmentPageRes> enrollPageRes = PageResponse.pagination(enrollmentPageRes, page);
 
     return new ResultResponse(SuccessType.SUCCESS_INQUIRY_ENROLLMENTS, enrollPageRes);
-
   }
+
+  // =================== 취소 ===================
 
   @Override
   @Transactional
@@ -118,8 +128,14 @@ public class EnrollmentServiceImpl implements EnrollmentService {
       throw new GlobalException(FailedType.ALREADY_CANCELLED);
     }
 
-    if(!enrollment.isCancellable()) {
+    if (!enrollment.isCancellable()) {
       throw new GlobalException(FailedType.CANCEL_PERIOD_EXPIRED);
+    }
+
+    // 대기 중 취소는 정원 복구 불필요
+    if (enrollment.isWaitlisted()) {
+      enrollment.cancel();
+      return ResultResponse.of(SuccessType.SUCCESS_CANCEL_ENROLLMENT);
     }
 
     Course course = courseRepository.findByIdWithLock(enrollment.getCourse().getCourseId())
@@ -127,7 +143,18 @@ public class EnrollmentServiceImpl implements EnrollmentService {
 
     course.decreaseEnrollmentCnt();
     enrollment.cancel();
+    promoteNextFromWaitlist(course);
 
     return ResultResponse.of(SuccessType.SUCCESS_CANCEL_ENROLLMENT);
+  }
+
+  // =================== 내부 메서드 ===================
+
+  private void promoteNextFromWaitlist(Course course) {
+    enrollmentRepository.findFirstWaitlistedByCourse(course)
+        .ifPresent(e -> {
+          e.promote();
+          course.increaseEnrollmentCnt();
+        });
   }
 }


### PR DESCRIPTION
## 작업 내용
> 정원이 꽉 찬 강의에 대기 신청을 할 수 있는 대기열 기능 구현
> 수강 취소 발생 시 대기 순서대로 자동 승격되며, 동시성은 기존 비관적 락 범위 안에서 안전하게 처리

## 주요 변경사항

### `EnrollmentStatus` 에 `WAITLISTED` 추가
```java
WAITLISTED("대기중")
```

### Enrollment 엔티티 도메인 메서드 추가
- `toWaitlistEntity()` : 대기 상태로 Enrollment 생성
- `isWaitlisted()` : 대기 중인지 여부 판별
- `promote()` : `WAITLISTED → PENDING` 상태 전환
- `isCancellable()` 수정 : `WAITLISTED` 도 언제든 취소 가능하도록 추가

### EnrollmentRepository 쿼리 추가
- `findFirstWaitlistedByCourse()` : 대기자 중 가장 먼저 신청한 사람 조회 (`createdAt ASC`)

### `enroll()` 로직 변경
기존에 정원 초과 시 예외를 던지던 로직을 대기 등록으로 변경함.

```
Before: 정원 초과 → COURSE_IS_FULL 예외
After:  정원 초과 → WAITLISTED 로 등록
```

검증 순서도 정리함.
```
사용자 존재 → 권한 → 강의 존재 → 강의 상태 → 중복 신청 → 시작일 → 정원 확인
```

### `cancelEnroll()` 에 대기자 승격 로직 추가
- 대기 중(`WAITLISTED`) 취소 시 정원 복구 없이 바로 취소 처리
- `PENDING`, `CONFIRMED` 취소 시 정원 복구 후 `promoteNextFromWaitlist()` 호출

### `promoteNextFromWaitlist()` 내부 메서드 추가
취소 발생 시 가장 먼저 대기한 사람을 `PENDING` 으로 자동 승격하고 정원을 다시 채움.

### Course 엔티티 `isNotAvailable()` 수정
대기 신청을 허용하기 위해 `CLOSED` 조건 제거.
```java
// Before
return courseStatus == CourseStatus.DRAFT || courseStatus == CourseStatus.CLOSED;

// After
return courseStatus == CourseStatus.DRAFT;
```

---

### 취소 시 대기자 자동 승격
대기자 승격(`promoteNextFromWaitlist()`)은 `cancelEnroll()` 에서 `findByIdWithLock()` 으로 이미 획득된 락 범위 안에서 실행
별도 락 없이 동시성을 안전하게 처리할 수 있음.

```
cancelEnroll()
    ↓
findByIdWithLock() 락 획득
    ↓
decreaseEnrollmentCnt() + cancel()
    ↓
promoteNextFromWaitlist()   ← 같은 락 범위 안에서 실행
    ↓
commit + 락 해제
```

### 대기 중 취소는 정원 복구 불필요
`WAITLISTED` 는 실제 정원을 차지하지 않은 상태이므로 취소 시 `decreaseEnrollmentCnt()` 를 호출하지 않음.

### 이미 시작된 강의 대기 신청 불가
`isStarted()` 체크를 `isFull()` 보다 앞에 두어, 시작일이 지난 강의는 대기 신청도 차단함.