### PR TITLE
[Refactor] 과제 A - 프로젝트 리펙토링

### DIFF
--- a/src/main/java/com/example/assignment/controller/CourseController.java
+++ b/src/main/java/com/example/assignment/controller/CourseController.java
@@ -2,14 +2,17 @@ package com.example.assignment.controller;
 
 import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.domain.dto.request.CourseReq;
+import com.example.assignment.domain.dto.request.CourseSearchReq;
 import com.example.assignment.domain.dto.request.CourseStatusReq;
 import com.example.assignment.domain.type.CourseStatus;
 import com.example.assignment.service.CourseService;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,6 +28,12 @@ public class CourseController {
 
   private final CourseService courseService;
 
+  /**
+   * 강의 등록
+   * POST /api/v1/course
+   * - 강사 전용
+   * - 동일한 강의 중복 등록 불가
+   */
   @PostMapping
   public ResponseEntity<ResultResponse> register(@RequestBody @Valid CourseReq courseReq) {
 
@@ -32,23 +41,28 @@ public class CourseController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  /**
+   * 강의 목록 조회
+   * GET /api/v1/course
+   * - 모든 조건은 선택값 (없으면 전체 조회)
+   * - 강사명, 제목, 가격 범위, 기간, 상태로 필터링 가능
+   * - 페이지네이션 적용 (기본 1페이지)
+   */
   @GetMapping
   public ResponseEntity<ResultResponse> getCourses(
-      @RequestParam(required = false) String creatorName,
-      @RequestParam(required = false) String title,
-      @RequestParam(required = false) Long minAmount,
-      @RequestParam(required = false) Long maxAmount,
-      @RequestParam(required = false) LocalDate startPeriodAt,
-      @RequestParam(required = false) LocalDate endPeriodAt,
-      @RequestParam(required = false) CourseStatus courseStatus,
-      @RequestParam(defaultValue = "1") int page
-  ) {
-    ResultResponse response = courseService.getCourses(creatorName, title,
-        minAmount, maxAmount, startPeriodAt, endPeriodAt, courseStatus, page);
+      @ParameterObject @ModelAttribute CourseSearchReq searchReq,
+      @RequestParam(defaultValue = "1") int page) {
+
+    ResultResponse response = courseService.getCourses(searchReq, page);
 
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  /**
+   * 강의 상세 조회
+   * GET /api/v1/course/{courseId}
+   * - 현재 수강 신청 인원 포함
+   */
   @GetMapping("/{courseId}")
   public ResponseEntity<ResultResponse> getCourseDetail(@PathVariable Long courseId) {
 
@@ -56,6 +70,14 @@ public class CourseController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  /**
+   * 강의 상태 변경
+   * PATCH /api/v1/course/{userId}/{courseId}/status
+   * - 강사 본인 강의만 변경 가능
+   * - 수강 기간이 만료된 강의는 변경 불가
+   * - 허용 전환: DRAFT → OPEN, DRAFT → CLOSED, OPEN → CLOSED
+   * - 불가 전환: CLOSED → OPEN, CLOSED → CLOSED, OPEN → OPEN
+   */
   @PatchMapping("/{userId}/{courseId}/status")
   public ResponseEntity<ResultResponse> updateCourseStatus(
       @PathVariable Long userId,
@@ -66,15 +88,19 @@ public class CourseController {
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  /**
+   * 강의별 수강생 목록 조회
+   * GET /api/v1/course/{userId}/{courseId}/enrollments
+   * - 강사 전용 (본인 강의만 조회 가능)
+   * - 최신순 정렬, 페이지네이션 적용
+   */
   @GetMapping("/{userId}/{courseId}/enrollments")
   public ResponseEntity<ResultResponse> getCourseEnrollments(
       @PathVariable Long userId,
       @PathVariable Long courseId,
-      @RequestParam(defaultValue = "1") int page
-  ) {
+      @RequestParam(defaultValue = "1") int page) {
 
     ResultResponse response = courseService.getCourseEnrollments(userId, courseId, page);
     return new ResponseEntity<>(response, response.getStatus());
   }
-
 }

--- a/src/main/java/com/example/assignment/controller/EnrollmentController.java
+++ b/src/main/java/com/example/assignment/controller/EnrollmentController.java
@@ -14,42 +14,69 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-
 @RequestMapping("/api/v1/enrollment")
 @RequiredArgsConstructor
 public class EnrollmentController {
 
   private final EnrollmentService enrollmentService;
 
+  /**
+   * 수강 신청
+   * POST /api/v1/enrollment/{userId}/{courseId}
+   * - 정원 여유 있으면 PENDING 으로 등록
+   * - 정원 초과 시 WAITLISTED 로 대기 등록
+   */
   @PostMapping("/{userId}/{courseId}")
-  public ResponseEntity<ResultResponse> enroll(@PathVariable Long userId,
+  public ResponseEntity<ResultResponse> enroll(
+      @PathVariable Long userId,
       @PathVariable Long courseId) {
 
-    ResultResponse response = enrollmentService.enroll(userId, courseId);
+    ResultResponse response = enrollmentService.enrollment(userId, courseId);
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  /**
+   * 결제 확정
+   * PATCH /api/v1/enrollment/{userId}/{enrollmentId}/pay
+   * - PENDING → CONFIRMED 상태 전환
+   */
   @PatchMapping("/{userId}/{enrollmentId}/pay")
-  public ResponseEntity<ResultResponse> payEnroll(@PathVariable Long userId,
+  public ResponseEntity<ResultResponse> payEnroll(
+      @PathVariable Long userId,
       @PathVariable Long enrollmentId) {
 
-    ResultResponse response = enrollmentService.payEnroll(userId, enrollmentId);
+    ResultResponse response = enrollmentService.payEnrollment(userId, enrollmentId);
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  /**
+   * 내 수강 신청 목록 조회
+   * GET /api/v1/enrollment/{userId}?page=1
+   * - 학생 전용
+   * - 최신순 정렬, 페이지네이션 적용
+   */
   @GetMapping("/{userId}")
-  public ResponseEntity<ResultResponse> getEnroll(@PathVariable Long userId,
+  public ResponseEntity<ResultResponse> getEnrollments(
+      @PathVariable Long userId,
       @RequestParam(defaultValue = "1") int page) {
 
-    ResultResponse response = enrollmentService.getEnroll(userId, page);
+    ResultResponse response = enrollmentService.getEnrollments(userId, page);
     return new ResponseEntity<>(response, response.getStatus());
   }
 
+  /**
+   * 수강 취소
+   * DELETE /api/v1/enrollment/{userId}/{enrollmentId}
+   * - PENDING, WAITLISTED: 언제든 취소 가능
+   * - CONFIRMED: 결제 후 7일 이내만 취소 가능
+   * - 취소 시 대기자 자동 승격
+   */
   @DeleteMapping("/{userId}/{enrollmentId}")
-  public ResponseEntity<ResultResponse> cancelled(@PathVariable Long userId,
+  public ResponseEntity<ResultResponse> cancelEnroll(
+      @PathVariable Long userId,
       @PathVariable Long enrollmentId) {
 
-    ResultResponse response = enrollmentService.cancelEnroll(userId, enrollmentId);
+    ResultResponse response = enrollmentService.cancelEnrollment(userId, enrollmentId);
     return new ResponseEntity<>(response, response.getStatus());
   }
 }

--- a/src/main/java/com/example/assignment/domain/dto/request/CourseSearchReq.java
+++ b/src/main/java/com/example/assignment/domain/dto/request/CourseSearchReq.java
@@ -4,8 +4,10 @@ import com.example.assignment.domain.type.CourseStatus;
 import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class CourseSearchReq {
 

--- a/src/main/java/com/example/assignment/domain/dto/response/CoursePageRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/CoursePageRes.java
@@ -1,5 +1,6 @@
 package com.example.assignment.domain.dto.response;
 
+import com.example.assignment.domain.dto.PageResponse;
 import com.example.assignment.domain.entity.Course;
 import java.time.LocalDate;
 import java.util.List;
@@ -26,8 +27,8 @@ public class CoursePageRes {
 
   private LocalDate endPeriodAt;
 
-  public static List<CoursePageRes> toList(List<Course> list) {
-    return list.stream()
+  public static PageResponse<CoursePageRes> toList(List<Course> list, int page) {
+    List<CoursePageRes> coursePageRes =  list.stream()
         .map(course ->
             new CoursePageRes(
                 course.getCourseId(),
@@ -40,5 +41,7 @@ public class CoursePageRes {
             )
         )
         .toList();
+
+    return PageResponse.pagination(coursePageRes, page);
   }
 }

--- a/src/main/java/com/example/assignment/domain/dto/response/EnrollmentPageRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/EnrollmentPageRes.java
@@ -1,5 +1,7 @@
 package com.example.assignment.domain.dto.response;
 
+import com.example.assignment.domain.dto.PageResponse;
+import com.example.assignment.domain.entity.Course;
 import com.example.assignment.domain.entity.Enrollment;
 import java.time.LocalDate;
 import java.util.List;
@@ -32,23 +34,27 @@ public class EnrollmentPageRes {
 
   private String enrollmentStatus;
 
-  public static List<EnrollmentPageRes> toList(List<Enrollment> list) {
-    return list.stream()
-        .map(enrollment ->
-            new EnrollmentPageRes(
-                enrollment.getEnrollmentId(),
-                enrollment.getCourse().getCourseId(),
-                enrollment.getCourse().getTitle(),
-                enrollment.getCourse().getDescription(),
-                enrollment.getCourse().getUser().getName(),
-                enrollment.getCourse().getCourseStatus().getValue(),
-                enrollment.getCourse().getStartPeriodAt(),
-                enrollment.getCourse().getEndPeriodAt(),
-                enrollment.getCourse().getEnrollmentCnt() + " / " + enrollment.getCourse().getPersonnel(),
-                enrollment.getEnrollmentStatus().getValue()
-            )
-        )
+  public static PageResponse<EnrollmentPageRes> toList(List<Enrollment> list, int page) {
+    List<EnrollmentPageRes> pageResList = list.stream()
+        .map(EnrollmentPageRes::from)
         .toList();
+
+    return PageResponse.pagination(pageResList, page);
   }
 
+  private static EnrollmentPageRes from(Enrollment enrollment) {
+    Course course = enrollment.getCourse();
+    return new EnrollmentPageRes(
+        enrollment.getEnrollmentId(),
+        course.getCourseId(),
+        course.getTitle(),
+        course.getDescription(),
+        course.getUser().getName(),
+        course.getCourseStatus().getValue(),
+        course.getStartPeriodAt(),
+        course.getEndPeriodAt(),
+        course.getEnrollmentCnt() + " / " + course.getPersonnel(),
+        enrollment.getEnrollmentStatus().getValue()
+    );
+  }
 }

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -51,6 +51,10 @@ public class Course extends BaseEntity {
 
   // =================== 정적 팩토리 메서드 ===================
 
+  /**
+   * Course 생성
+   * 강의 등록 시 enrollmentCnt 를 0 으로 초기화
+   */
   public static Course toEntity(CourseReq courseReq, User user) {
     return Course.builder()
         .title(courseReq.getTitle())
@@ -67,38 +71,73 @@ public class Course extends BaseEntity {
 
   // =================== 상태 판별 ===================
 
+  /**
+   * 수강 신청 불가 상태 여부 확인
+   * DRAFT 상태는 신청 불가
+   * CLOSED 는 정원 초과 대기 신청이 가능하므로 제외
+   */
   public boolean isNotAvailable() {
     return courseStatus == CourseStatus.DRAFT;
   }
 
+  /**
+   * 모집 중(OPEN) 상태 여부 확인
+   * 강의 상태 변경 시 중복 전환 방지에 사용
+   */
   public boolean isOpen() {
     return courseStatus == CourseStatus.OPEN;
   }
 
+  /**
+   * 모집 마감(CLOSED) 상태 여부 확인
+   * 강의 상태 변경 및 정원 복구 시 사용
+   */
   public boolean isClosed() {
     return courseStatus == CourseStatus.CLOSED;
   }
 
+  /**
+   * 본인 강의 여부 확인
+   * 강의 상태 변경 및 수강생 목록 조회 시 타인 강의 접근 방지에 사용
+   */
   public boolean isNotOwnedBy(Long userId) {
     return !this.user.getUserId().equals(userId);
   }
 
   // =================== 기간 판별 ===================
 
+  /**
+   * 강의 시작 여부 확인
+   * 시작일이 지난 강의는 수강 신청 및 대기 신청 불가
+   */
   public boolean isStarted() {
     return this.startPeriodAt.isBefore(LocalDate.now());
   }
 
+  /**
+   * 강의 기간 만료 여부 확인
+   * 종료일이 지난 강의는 상태 변경 불가
+   */
   public boolean isExpired() {
     return this.endPeriodAt.isBefore(LocalDate.now());
   }
 
   // =================== 정원 관리 ===================
 
+  /**
+   * 정원 마감 여부 확인
+   * 신청 인원(enrollmentCnt) 이 최대 정원(personnel) 에 도달하면 true
+   * 수강 신청 시 대기열 등록 여부 판단에 사용
+   */
   public boolean isFull() {
     return enrollmentCnt >= personnel;
   }
 
+  /**
+   * 수강 인원 증가
+   * 수강 신청 시 호출
+   * 정원이 꽉 차면 자동으로 CLOSED 상태로 전환
+   */
   public void increaseEnrollmentCnt() {
     this.enrollmentCnt++;
     if (this.isFull()) {
@@ -106,6 +145,11 @@ public class Course extends BaseEntity {
     }
   }
 
+  /**
+   * 수강 인원 감소
+   * 수강 취소 또는 대기자 승격 실패 시 호출
+   * CLOSED 상태에서 자리가 생기면 자동으로 OPEN 으로 복귀
+   */
   public void decreaseEnrollmentCnt() {
     if (this.enrollmentCnt > 0) {
       this.enrollmentCnt--;
@@ -117,10 +161,20 @@ public class Course extends BaseEntity {
 
   // =================== 상태 변경 ===================
 
+  /**
+   * 강의 상태를 모집 중(OPEN) 으로 변경
+   * DRAFT 또는 CLOSED 상태에서 호출
+   * 호출 전 상태 유효성 검증은 서비스 레이어에서 담당
+   */
   public void openCourse() {
     this.courseStatus = CourseStatus.OPEN;
   }
 
+  /**
+   * 강의 상태를 모집 마감(CLOSED) 으로 변경
+   * 강사의 수동 마감 또는 정원 초과 시 자동 마감에 사용
+   * 호출 전 상태 유효성 검증은 서비스 레이어에서 담당
+   */
   public void closeCourse() {
     this.courseStatus = CourseStatus.CLOSED;
   }

--- a/src/main/java/com/example/assignment/domain/entity/Enrollment.java
+++ b/src/main/java/com/example/assignment/domain/entity/Enrollment.java
@@ -40,40 +40,59 @@ public class Enrollment extends BaseEntity {
 
   // =================== 정적 팩토리 메서드 ===================
 
-  public static Enrollment toEntity(Course course, User user) {
+  /**
+   * Enrollment 생성
+   * PENDING  → 일반 수강 신청
+   * WAITLISTED → 정원 초과로 인한 대기 신청
+   */
+  public static Enrollment toEntity(Course course, User user, EnrollmentStatus status) {
     return Enrollment.builder()
         .course(course)
         .user(user)
-        .enrollmentStatus(EnrollmentStatus.PENDING)
-        .build();
-  }
-
-  public static Enrollment toWaitlistEntity(Course course, User user) {
-    return Enrollment.builder()
-        .course(course)
-        .user(user)
-        .enrollmentStatus(EnrollmentStatus.WAITLISTED)
+        .enrollmentStatus(status)
         .build();
   }
 
   // =================== 상태 판별 ===================
 
+  /**
+   * 본인 수강 신청 여부 확인
+   * 결제, 취소 시 타인의 수강 신청에 접근하는 것을 방지
+   */
   public boolean isNotOwnedBy(Long userId) {
     return !this.user.getUserId().equals(userId);
   }
 
+  /**
+   * 결제 완료(CONFIRMED) 상태 여부 확인
+   * 중복 결제 방지에 사용
+   */
   public boolean isConfirmed() {
     return enrollmentStatus == EnrollmentStatus.CONFIRMED;
   }
 
+  /**
+   * 취소(CANCELLED) 상태 여부 확인
+   * 재취소 및 취소된 건의 결제 방지에 사용
+   */
   public boolean isCancelled() {
     return enrollmentStatus == EnrollmentStatus.CANCELLED;
   }
 
+  /**
+   * 대기(WAITLISTED) 상태 여부 확인
+   * 대기 중 취소 시 정원 복구 생략 여부 판단에 사용
+   */
   public boolean isWaitlisted() {
     return enrollmentStatus == EnrollmentStatus.WAITLISTED;
   }
 
+  /**
+   * 취소 가능 여부 확인
+   * - PENDING, WAITLISTED: 결제 전이므로 언제든 취소 가능
+   * - CONFIRMED: 결제 완료 시점(updatedAt) 기준 7일 이내만 취소 가능
+   * - CANCELLED: 취소 불가 (false 반환)
+   */
   public boolean isCancellable() {
     if (this.enrollmentStatus == EnrollmentStatus.PENDING
         || this.enrollmentStatus == EnrollmentStatus.WAITLISTED) {
@@ -89,14 +108,29 @@ public class Enrollment extends BaseEntity {
 
   // =================== 상태 변경 ===================
 
+  /**
+   * 결제 확정
+   * PENDING → CONFIRMED 상태 전환
+   * 호출 시점에 JPA Auditing 이 updatedAt 을 갱신하며,
+   * 이 시점이 취소 가능 기간(7일)의 기준이 됨
+   */
   public void confirm() {
     this.enrollmentStatus = EnrollmentStatus.CONFIRMED;
   }
 
+  /**
+   * 수강 취소
+   * PENDING, CONFIRMED, WAITLISTED → CANCELLED 상태 전환
+   */
   public void cancel() {
     this.enrollmentStatus = EnrollmentStatus.CANCELLED;
   }
 
+  /**
+   * 대기자 승격
+   * WAITLISTED → PENDING 상태 전환
+   * 다른 수강생의 취소로 자리가 생겼을 때 호출됨
+   */
   public void promote() {
     this.enrollmentStatus = EnrollmentStatus.PENDING;
   }

--- a/src/main/java/com/example/assignment/domain/repository/querydsl/CourseQueryRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/querydsl/CourseQueryRepository.java
@@ -1,5 +1,6 @@
 package com.example.assignment.domain.repository.querydsl;
 
+import com.example.assignment.domain.dto.request.CourseSearchReq;
 import com.example.assignment.domain.entity.Course;
 import com.example.assignment.domain.entity.QCourse;
 import com.example.assignment.domain.type.CourseStatus;
@@ -17,53 +18,57 @@ public class CourseQueryRepository {
 
   private final JPAQueryFactory queryFactory;
 
-  public List<Course> searchCourses(String creatorName, String title, Long minAmount, Long maxAmount,
-      LocalDate startPeriodAt, LocalDate endPeriodAt, CourseStatus courseStatus) {
+
+  /**
+   * 강의 목록 동적 조회
+   * 조건이 null 이면 해당 조건은 자동으로 제외됨
+   */
+  public List<Course> searchCourses(CourseSearchReq searchReq) {
     QCourse course = QCourse.course;
 
     return queryFactory
         .selectFrom(course)
         .leftJoin(course.user).fetchJoin()
         .where(
-            creatorNameEq(creatorName),
-            titleContains(title),
-            amountGoe(minAmount),
-            amountLoe(maxAmount),
-            startPeriodAtGoe(startPeriodAt),
-            endPeriodAtLoe(endPeriodAt),
-            courseStatusEq(courseStatus)
+            creatorNameEq(course, searchReq.getCreatorName()),
+            titleContains(course, searchReq.getTitle()),
+            amountGoe(course, searchReq.getMinAmount()),
+            amountLoe(course, searchReq.getMaxAmount()),
+            startPeriodAtGoe(course, searchReq.getStartPeriodAt()),
+            endPeriodAtLoe(course, searchReq.getEndPeriodAt()),
+            courseStatusEq(course, searchReq.getCourseStatus())
         )
         .fetch();
   }
 
-  // null이면 조건 자체를 제외 (동적 쿼리 핵심)
-  private BooleanExpression creatorNameEq(String name) {
-    return name == null ? null : QCourse.course.user.name.eq(name)
-        .and(QCourse.course.user.userRole.eq(UserRole.CREATORS));
+  // null 이면 조건 자체를 제외 (동적 쿼리 핵심)
+
+  private BooleanExpression creatorNameEq(QCourse course, String name) {
+    return (name == null || name.isBlank()) ? null
+        : course.user.name.eq(name).and(course.user.userRole.eq(UserRole.CREATORS));
   }
 
-  private BooleanExpression titleContains(String title) {
-    return title == null ? null : QCourse.course.title.contains(title);
+  private BooleanExpression titleContains(QCourse course, String title) {
+    return (title == null || title.isBlank()) ? null : course.title.contains(title);
   }
 
-  private BooleanExpression amountGoe(Long minAmount) {
-    return minAmount == null ? null : QCourse.course.amount.goe(minAmount);
+  private BooleanExpression amountGoe(QCourse course, Long minAmount) {
+    return minAmount == null ? null : course.amount.goe(minAmount);
   }
 
-  private BooleanExpression amountLoe(Long maxAmount) {
-    return maxAmount == null ? null : QCourse.course.amount.loe(maxAmount);
+  private BooleanExpression amountLoe(QCourse course, Long maxAmount) {
+    return maxAmount == null ? null : course.amount.loe(maxAmount);
   }
 
-  private BooleanExpression startPeriodAtGoe(LocalDate date) {
-    return date == null ? null : QCourse.course.startPeriodAt.goe(date);
+  private BooleanExpression startPeriodAtGoe(QCourse course, LocalDate date) {
+    return date == null ? null : course.startPeriodAt.goe(date);
   }
 
-  private BooleanExpression endPeriodAtLoe(LocalDate date) {
-    return date == null ? null : QCourse.course.endPeriodAt.loe(date);
+  private BooleanExpression endPeriodAtLoe(QCourse course, LocalDate date) {
+    return date == null ? null : course.endPeriodAt.loe(date);
   }
 
-  private BooleanExpression courseStatusEq(CourseStatus status) {
-    return status == null ? null : QCourse.course.courseStatus.eq(status);
+  private BooleanExpression courseStatusEq(QCourse course, CourseStatus status) {
+    return status == null ? null : course.courseStatus.eq(status);
   }
-
 }

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -7,22 +7,32 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum FailedType {
+
+  // =================== 사용자 ===================
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
-  ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 작업에 대한 권한이 없습니다."),
-  COURSE_IS_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 등록한 강의 입니다."),
-  COURSE_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 강의 입니다.."),
-  COURSE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "현재 수강신청이 불가능한 강의입니다."),
+  ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+  // =================== 강의 ===================
+  COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 강의입니다."),
+  COURSE_IS_DUPLICATE(HttpStatus.CONFLICT, "이미 등록된 강의입니다."),
+  COURSE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "현재 수강신청이 가능한 강의가 아닙니다."),
   COURSE_IS_FULL(HttpStatus.BAD_REQUEST, "수강 정원이 마감되었습니다."),
-  ALREADY_ENROLLED(HttpStatus.CONFLICT, "이미 수강신청한 강의입니다."),
-  ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 수강신청 내역입니다."),
-  ALREADY_PAID(HttpStatus.BAD_REQUEST, "이미 결제가 완료된 수강신청입니다."),
-  ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 수강신청입니다."),
-  COURSE_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "수강 기간이 만료된 강의입니다."),
+  COURSE_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 시작된 강의는 신청할 수 없습니다."),
+  COURSE_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "수강 기간이 종료된 강의입니다."),
+
+  // =================== 강의 상태 변경 ===================
   COURSE_ALREADY_OPEN(HttpStatus.BAD_REQUEST, "이미 모집 중인 강의입니다."),
   COURSE_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "이미 마감된 강의입니다."),
   INVALID_COURSE_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "해당 상태로는 변경할 수 없습니다."),
+
+  // =================== 수강 신청 ===================
+  ALREADY_ENROLLED(HttpStatus.CONFLICT, "이미 수강신청한 강의입니다."),
+  ENROLLMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 수강신청 내역입니다."),
   CANCEL_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "취소 가능 기간(결제 후 7일)이 지났습니다."),
-  COURSE_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 시작된 강의는 신청할 수 없습니다."),
+
+  // =================== 결제 ===================
+  ALREADY_PAID(HttpStatus.CONFLICT, "이미 결제가 완료된 수강신청입니다."),
+  ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 수강신청입니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -7,16 +7,22 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum SuccessType {
-  SUCCESS_REGISTRATION_COURSE(HttpStatus.OK, "강의를 성공적으로 등록하였습니다."),
-  SUCCESS_INQUIRY_COURSES(HttpStatus.OK, "강의 목록을 성공적으로 조회하였습니다."),
-  SUCCESS_INQUIRY_COURSES_DETAIL(HttpStatus.OK, "강의 상세 정보를 성공적으로 조회하였습니다."),
-  SUCCESS_ENROLLMENT(HttpStatus.OK, "수강신청이 성공적으로 완료되었습니다."),
-  SUCCESS_PAYMENT(HttpStatus.OK, "결제가 성공적으로 완료되었습니다."),
-  SUCCESS_INQUIRY_ENROLLMENTS(HttpStatus.OK, "내 수강 신청 목록을 성공적으로 조회하였습니다."),
-  SUCCESS_CANCEL_ENROLLMENT(HttpStatus.OK, "신청한 수강을 성공적으로 취소하였습니다."),
-  SUCCESS_UPDATE_COURSE_STATUS(HttpStatus.OK, "강의 상태를 성공적으로 변경하였습니다."),
+
+  // =================== 강의 ===================
+  SUCCESS_REGISTRATION_COURSE(HttpStatus.CREATED, "강의가 등록되었습니다."),
+  SUCCESS_INQUIRY_COURSES(HttpStatus.OK, "강의 목록을 조회했습니다."),
+  SUCCESS_INQUIRY_COURSES_DETAIL(HttpStatus.OK, "강의 상세 정보를 조회했습니다."),
+  SUCCESS_UPDATE_COURSE_STATUS(HttpStatus.OK, "강의 상태가 변경되었습니다."),
   SUCCESS_INQUIRY_COURSE_ENROLLMENTS(HttpStatus.OK, "수강생 목록을 조회했습니다."),
-  SUCCESS_WAITLISTED(HttpStatus.OK, "정원이 마감되어 대기 신청이 되었습니다."),
+
+  // =================== 수강 신청 ===================
+  SUCCESS_ENROLLMENT(HttpStatus.CREATED, "수강신청이 완료되었습니다."),
+  SUCCESS_WAITLISTED(HttpStatus.OK, "정원이 마감되어 대기 신청이 완료되었습니다."),
+  SUCCESS_INQUIRY_ENROLLMENTS(HttpStatus.OK, "수강신청 목록을 조회했습니다."),
+  SUCCESS_CANCEL_ENROLLMENT(HttpStatus.OK, "수강신청이 취소되었습니다."),
+
+  // =================== 결제 ===================
+  SUCCESS_PAYMENT(HttpStatus.OK, "결제가 완료되었습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/service/CourseService.java
+++ b/src/main/java/com/example/assignment/service/CourseService.java
@@ -2,6 +2,7 @@ package com.example.assignment.service;
 
 import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.domain.dto.request.CourseReq;
+import com.example.assignment.domain.dto.request.CourseSearchReq;
 import com.example.assignment.domain.dto.request.CourseStatusReq;
 import com.example.assignment.domain.type.CourseStatus;
 import jakarta.validation.Valid;
@@ -11,8 +12,7 @@ public interface CourseService {
 
   ResultResponse register(@Valid CourseReq courseReq);
 
-  ResultResponse getCourses(String creatorName, String title, Long minAmount, Long maxAmount,
-      LocalDate startPeriodAt, LocalDate endPeriodAt, CourseStatus courseStatus, int page);
+  ResultResponse getCourses(CourseSearchReq searchReq, int page);
 
   ResultResponse getCourseDetail(Long courseId);
 

--- a/src/main/java/com/example/assignment/service/EnrollmentService.java
+++ b/src/main/java/com/example/assignment/service/EnrollmentService.java
@@ -4,11 +4,11 @@ import com.example.assignment.domain.dto.ResultResponse;
 
 public interface EnrollmentService {
 
-  ResultResponse enroll(Long userId, Long courseId);
+  ResultResponse enrollment(Long userId, Long courseId);
 
-  ResultResponse payEnroll(Long userId, Long enrollmentId);
+  ResultResponse payEnrollment(Long userId, Long enrollmentId);
 
-  ResultResponse getEnroll(Long userId, int page);
+  ResultResponse getEnrollments(Long userId, int page);
 
-  ResultResponse cancelEnroll(Long userId, Long enrollmentId);
+  ResultResponse cancelEnrollment(Long userId, Long enrollmentId);
 }

--- a/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.assignment.service.impl;
 import com.example.assignment.domain.dto.PageResponse;
 import com.example.assignment.domain.dto.ResultResponse;
 import com.example.assignment.domain.dto.request.CourseReq;
+import com.example.assignment.domain.dto.request.CourseSearchReq;
 import com.example.assignment.domain.dto.request.CourseStatusReq;
 import com.example.assignment.domain.dto.response.CourseEnrollmentRes;
 import com.example.assignment.domain.dto.response.CoursePageRes;
@@ -34,94 +35,96 @@ public class CourseServiceImpl implements CourseService {
   private final CourseQueryRepository courseQueryRepository;
   private final EnrollmentRepository enrollmentRepository;
 
+  /**
+   * 강의 등록
+   * - 모든 필드가 동일한 강의 중복 등록 불가
+   */
   @Override
   @Transactional
   public ResultResponse register(CourseReq courseReq) {
 
-    User user = userRepository.findById(courseReq.getUserId())
-        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+    User user = getUser(courseReq.getUserId());
 
-    // security 설정 없어서 임시로 설정
-    if (user.isStudent()) {
-      throw new GlobalException(FailedType.ACCESS_DENIED);
-    }
+    // TODO: 로그인 기능 및 인증/인가 로직 미구현으로 userId 를 직접 받는 방식으로 대체
+    if (user.isStudent()) throw new GlobalException(FailedType.ACCESS_DENIED);
 
-    boolean isDuplicate = courseRepository.existsDuplicateCourse(
-        user,
-        courseReq.getTitle(),
-        courseReq.getDescription(),
-        courseReq.getAmount(),
-        courseReq.getPersonnel(),
-        courseReq.getStartPeriodAt(),
-        courseReq.getEndPeriodAt(),
-        courseReq.getCourseStatus()
-    );
+    if (isDuplicateCourse(user, courseReq)) throw new GlobalException(FailedType.COURSE_IS_DUPLICATE);
 
-    if(isDuplicate) throw new GlobalException(FailedType.COURSE_IS_DUPLICATE);
-
-    Course course = Course.toEntity(courseReq, user);
-
-    courseRepository.save(course);
+    courseRepository.save(Course.toEntity(courseReq, user));
 
     return ResultResponse.of(SuccessType.SUCCESS_REGISTRATION_COURSE);
   }
 
+  /**
+   * 강의 목록 조회
+   * - 모든 조건은 선택값 (없으면 전체 조회)
+   * - 강사명, 제목, 가격 범위, 기간, 상태로 필터링 가능
+   * - 페이지네이션 적용 (기본 1페이지)
+   */
   @Override
   @Transactional(readOnly = true)
-  public ResultResponse getCourses(String creatorName, String title, Long minAmount, Long maxAmount,
-      LocalDate startPeriodAt, LocalDate endPeriodAt, CourseStatus courseStatus, int page) {
+  public ResultResponse getCourses(CourseSearchReq searchReq, int page) {
 
-    List<Course> courses = courseQueryRepository.searchCourses(creatorName, title, minAmount,
-        maxAmount, startPeriodAt, endPeriodAt, courseStatus);
+    List<Course> courses = courseQueryRepository.searchCourses(searchReq);
 
-    List<CoursePageRes> courseRes = CoursePageRes.toList(courses);
+    PageResponse<CoursePageRes> response = CoursePageRes.toList(courses, page);
 
-    PageResponse<CoursePageRes> pageResponse = PageResponse.pagination(courseRes, page);
-    return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSES, pageResponse);
+    return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSES, response);
   }
 
+  /**
+   * 강의 상세 조회
+   * - 현재 수강 신청 인원 포함
+   */
   @Override
   @Transactional(readOnly = true)
   public ResultResponse getCourseDetail(Long courseId) {
 
-    Course course = courseRepository.findById(courseId)
-        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+    Course course = getCourse(courseId);
+    CourseRes response = CourseRes.of(course);
 
-    CourseRes courseRes = CourseRes.of(course);
-    return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSES_DETAIL, courseRes);
+    return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSES_DETAIL, response);
   }
 
+  /**
+   * 강의 상태 변경
+   * - 수강 기간 만료 시 변경 불가
+   * - 허용 전환: DRAFT → OPEN, DRAFT → CLOSED, OPEN → CLOSED
+   * - 불가 전환: CLOSED → OPEN, CLOSED → CLOSED, OPEN → OPEN
+   * - 조기 마감 시 동시성 방지를 위해 비관적 락 적용
+   */
   @Override
   @Transactional
   public ResultResponse updateCourseStatus(Long userId, Long courseId, CourseStatusReq courseStatusReq) {
 
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+    User user = getUser(userId);
 
+    // TODO: 로그인 기능 및 인증/인가 로직 미구현으로 userId 를 직접 받는 방식으로 대체
     if (user.isStudent()) {
       throw new GlobalException(FailedType.ACCESS_DENIED);
     }
 
-    Course course = courseRepository.findByIdWithLock(courseId)
-        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+    Course course = getCourseWithLock(courseId);
 
     if (course.isNotOwnedBy(userId)) {
       throw new GlobalException(FailedType.ACCESS_DENIED);
     }
 
-    if(course.isExpired()) {
+    if (course.isExpired()) {
       throw new GlobalException(FailedType.COURSE_PERIOD_EXPIRED);
     }
 
-    if(courseStatusReq.getCourseStatus() == CourseStatus.OPEN) {
+    CourseStatus status = courseStatusReq.getCourseStatus();
+
+    if (status == CourseStatus.OPEN) {
       if (course.isOpen()) throw new GlobalException(FailedType.COURSE_ALREADY_OPEN);
       if (course.isClosed()) throw new GlobalException(FailedType.COURSE_ALREADY_CLOSED);
       course.openCourse();
 
-    } else if(courseStatusReq.getCourseStatus() == CourseStatus.CLOSED) {
+    } else if (status == CourseStatus.CLOSED) {
       if (course.isClosed()) throw new GlobalException(FailedType.COURSE_ALREADY_CLOSED);
-
       course.closeCourse();
+
     } else {
       throw new GlobalException(FailedType.INVALID_COURSE_STATUS_TRANSITION);
     }
@@ -129,18 +132,24 @@ public class CourseServiceImpl implements CourseService {
     return ResultResponse.of(SuccessType.SUCCESS_UPDATE_COURSE_STATUS);
   }
 
+  // =================== 수강생 목록 조회 ===================
+
+  /**
+   * 강의별 수강생 목록 조회
+   * - 최신순 정렬, 페이지네이션 적용
+   */
   @Override
   @Transactional(readOnly = true)
   public ResultResponse getCourseEnrollments(Long userId, Long courseId, int page) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
 
+    User user = getUser(userId);
+
+    // TODO: 로그인 기능 및 인증/인가 로직 미구현으로 userId 를 직접 받는 방식으로 대체
     if (user.isStudent()) {
       throw new GlobalException(FailedType.ACCESS_DENIED);
     }
 
-    Course course = courseRepository.findById(courseId)
-        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+    Course course = getCourse(courseId);
 
     if (course.isNotOwnedBy(userId)) {
       throw new GlobalException(FailedType.ACCESS_DENIED);
@@ -150,5 +159,44 @@ public class CourseServiceImpl implements CourseService {
     CourseEnrollmentRes response = CourseEnrollmentRes.of(course, enrollments, page);
 
     return new ResultResponse(SuccessType.SUCCESS_INQUIRY_COURSE_ENROLLMENTS, response);
+  }
+
+  // =================== 내부 메서드 ===================
+
+  private User getUser(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+  }
+
+  private Course getCourse(Long courseId) {
+    return courseRepository.findById(courseId)
+        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+  }
+
+  /**
+   * courseId 로 Course 조회 (비관적 락 적용)
+   * 강의 상태 변경 시 동시 수강 신청과의 경합 방지
+   * 존재하지 않으면 COURSE_NOT_FOUND 예외 발생
+   */
+  private Course getCourseWithLock(Long courseId) {
+    return courseRepository.findByIdWithLock(courseId)
+        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+  }
+
+  /**
+   * 강의 중복 여부 확인
+   * 동일 강사가 모든 필드가 같은 강의를 등록하는 경우 중복으로 판단
+   */
+  private boolean isDuplicateCourse(User user, CourseReq courseReq) {
+    return courseRepository.existsDuplicateCourse(
+        user,
+        courseReq.getTitle(),
+        courseReq.getDescription(),
+        courseReq.getAmount(),
+        courseReq.getPersonnel(),
+        courseReq.getStartPeriodAt(),
+        courseReq.getEndPeriodAt(),
+        courseReq.getCourseStatus()
+    );
   }
 }

--- a/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
@@ -27,21 +27,26 @@ public class EnrollmentServiceImpl implements EnrollmentService {
   private final CourseRepository courseRepository;
   private final UserRepository userRepository;
 
-  // =================== 수강 신청 ===================
-
+  /**
+   * 수강 신청
+   * - 강사는 수강 신청 불가
+   * - DRAFT 상태 강의는 신청 불가
+   * - 이미 신청(PENDING, CONFIRMED, WAITLISTED)한 강의는 재신청 불가
+   * - 시작일이 지난 강의는 신청 불가
+   * - 정원이 꽉 찬 경우 대기열(WAITLISTED)에 등록
+   */
   @Override
   @Transactional
-  public ResultResponse enroll(Long userId, Long courseId) {
+  public ResultResponse enrollment(Long userId, Long courseId) {
 
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+    User user = getUser(userId);
 
+    // TODO: 로그인 기능 및 인증/인가 로직 미구현으로 userId 를 직접 받는 방식으로 대체
     if (user.isCreator()) {
       throw new GlobalException(FailedType.ACCESS_DENIED);
     }
 
-    Course course = courseRepository.findByIdWithLock(courseId)
-        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+    Course course = getCourse(courseId);
 
     if (course.isNotAvailable()) {
       throw new GlobalException(FailedType.COURSE_NOT_AVAILABLE);
@@ -57,26 +62,31 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     }
 
     if (course.isFull()) {
-      Enrollment waitlist = Enrollment.toWaitlistEntity(course, user);
+      Enrollment waitlist = Enrollment.toEntity(course, user, EnrollmentStatus.WAITLISTED);
       enrollmentRepository.save(waitlist);
+
       return ResultResponse.of(SuccessType.SUCCESS_WAITLISTED);
     }
 
-    Enrollment enrollment = Enrollment.toEntity(course, user);
+    Enrollment enrollment = Enrollment.toEntity(course, user, EnrollmentStatus.PENDING);
     enrollmentRepository.save(enrollment);
     course.increaseEnrollmentCnt();
 
     return ResultResponse.of(SuccessType.SUCCESS_ENROLLMENT);
   }
 
-  // =================== 결제 ===================
-
+  /**
+   * 결제 확정
+   * - 본인 수강 신청 건만 결제 가능
+   * - 이미 결제(CONFIRMED)된 건은 재결제 불가
+   * - 취소(CANCELLED)된 건은 결제 불가
+   * - 결제 완료 시 PENDING → CONFIRMED 상태 전환
+   */
   @Override
   @Transactional
-  public ResultResponse payEnroll(Long userId, Long enrollmentId) {
+  public ResultResponse payEnrollment(Long userId, Long enrollmentId) {
 
-    Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
-        .orElseThrow(() -> new GlobalException(FailedType.ENROLLMENT_NOT_FOUND));
+    Enrollment enrollment = getEnrollment(enrollmentId);
 
     if (enrollment.isNotOwnedBy(userId)) {
       throw new GlobalException(FailedType.ACCESS_DENIED);
@@ -95,30 +105,43 @@ public class EnrollmentServiceImpl implements EnrollmentService {
     return ResultResponse.of(SuccessType.SUCCESS_PAYMENT);
   }
 
-  // =================== 조회 ===================
-
+  /**
+   * 내 수강 신청 목록 조회
+   * - 강사는 조회 불가 (학생 전용)
+   * - 최신순 정렬
+   * - 페이지네이션 적용 (기본 1페이지, 10개)
+   */
   @Override
   @Transactional(readOnly = true)
-  public ResultResponse getEnroll(Long userId, int page) {
+  public ResultResponse getEnrollments(Long userId, int page) {
 
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+    User user = getUser(userId);
+
+    // TODO: 로그인 기능 및 인증/인가 로직 미구현으로 userId 를 직접 받는 방식으로 대체
+    if (user.isCreator()) {
+      throw new GlobalException(FailedType.ACCESS_DENIED);
+    }
 
     List<Enrollment> enrollments = enrollmentRepository.findAllByUserWithCourse(user);
-    List<EnrollmentPageRes> enrollmentPageRes = EnrollmentPageRes.toList(enrollments);
-    PageResponse<EnrollmentPageRes> enrollPageRes = PageResponse.pagination(enrollmentPageRes, page);
+    PageResponse<EnrollmentPageRes> enrollPageRes = EnrollmentPageRes.toList(enrollments, page);
 
     return new ResultResponse(SuccessType.SUCCESS_INQUIRY_ENROLLMENTS, enrollPageRes);
   }
 
-  // =================== 취소 ===================
-
+  /**
+   * 수강 취소
+   * - 본인 수강 신청 건만 취소 가능
+   * - 이미 취소된 건은 재취소 불가
+   * - PENDING, WAITLISTED 는 언제든 취소 가능
+   * - CONFIRMED 는 결제 후 7일 이내만 취소 가능
+   * - WAITLISTED 취소 시 정원 복구 없이 상태만 변경
+   * - PENDING, CONFIRMED 취소 시 정원 복구 후 대기자 자동 승격
+   */
   @Override
   @Transactional
-  public ResultResponse cancelEnroll(Long userId, Long enrollmentId) {
+  public ResultResponse cancelEnrollment(Long userId, Long enrollmentId) {
 
-    Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
-        .orElseThrow(() -> new GlobalException(FailedType.ENROLLMENT_NOT_FOUND));
+    Enrollment enrollment = getEnrollment(enrollmentId);
 
     if (enrollment.isNotOwnedBy(userId)) {
       throw new GlobalException(FailedType.ACCESS_DENIED);
@@ -132,14 +155,12 @@ public class EnrollmentServiceImpl implements EnrollmentService {
       throw new GlobalException(FailedType.CANCEL_PERIOD_EXPIRED);
     }
 
-    // 대기 중 취소는 정원 복구 불필요
     if (enrollment.isWaitlisted()) {
       enrollment.cancel();
       return ResultResponse.of(SuccessType.SUCCESS_CANCEL_ENROLLMENT);
     }
 
-    Course course = courseRepository.findByIdWithLock(enrollment.getCourse().getCourseId())
-        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+    Course course = getCourse(enrollment.getCourse().getCourseId());
 
     course.decreaseEnrollmentCnt();
     enrollment.cancel();
@@ -150,10 +171,25 @@ public class EnrollmentServiceImpl implements EnrollmentService {
 
   // =================== 내부 메서드 ===================
 
+  private User getUser(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+  }
+
+  private Course getCourse(Long courseId) {
+    return courseRepository.findByIdWithLock(courseId)
+        .orElseThrow(() -> new GlobalException(FailedType.COURSE_NOT_FOUND));
+  }
+
+  private Enrollment getEnrollment(Long enrollmentId) {
+    return enrollmentRepository.findById(enrollmentId)
+        .orElseThrow(() -> new GlobalException(FailedType.ENROLLMENT_NOT_FOUND));
+  }
+
   private void promoteNextFromWaitlist(Course course) {
     enrollmentRepository.findFirstWaitlistedByCourse(course)
-        .ifPresent(e -> {
-          e.promote();
+        .ifPresent(enrollment -> {
+          enrollment.promote();
           course.increaseEnrollmentCnt();
         });
   }


### PR DESCRIPTION
## 작업 내용
> 코드 가독성, 일관성, 유지보수성을 높이기 위한 전반적인 리팩토링 진행
> 주석 추가, 메서드명 통일, 중복 코드 제거, DTO 구조 개선 포함

## 주요 변경사항

### 응답 상수 정리 (`SuccessType`, `FailedType`)
- 상황별 그룹으로 분리 (강의 / 수강 신청 / 결제 / 강의 상태 변경 등)
- HTTP 상태 코드 정확성 개선
  - 리소스 생성: `200 OK` → `201 Created`
  - 리소스 없음: `400` → `404 Not Found`
  - 상태 충돌: `400` → `409 Conflict`
- 오탈자 수정 (`"존재하지 않는 강의 입니다.."` → `"존재하지 않는 강의입니다."`)
- 메시지 간결하게 통일 (`"성공적으로 ~하였습니다."` → `"~했습니다."`)

### 컨트롤러 개선
- 메서드별 주석 추가 (URL, 역할, 조건)
- 메서드명 통일
  - `getEnroll()` → `getEnrollments()` (복수형)
- 강의 목록 조회: 다수의 `@RequestParam` → `@ModelAttribute` + `@ParameterObject` 로 개선
  - `CourseSearchReq` 에 `@Setter` 추가 (바인딩 처리)

### 서비스 레이어 개선
- 메서드별 주석 추가 (역할, 검증 조건)
- 반복되는 조회 로직을 내부 메서드로 분리
  - `getUser()`, `getCourse()`, `getCourseWithLock()`, `getEnrollment()`
- 중복 강의 검증 로직을 `isDuplicateCourse()` 로 분리
- 임시 권한 처리 로직 주석 추가
- `EnrollmentService` 인터페이스 메서드명 변경
  - `enroll()` → `enrollment()`
  - `payEnroll()` → `payEnrollment()`
  - `getEnroll()` → `getEnrollments()`
  - `cancelEnroll()` → `cancelEnrollment()`

### 엔티티 개선
- 메서드별 주석 추가 (역할, 사용 시점, 주의사항)
- `Enrollment.toEntity()`, `toWaitlistEntity()` → `toEntity(status)` 로 통합
```java
  // Before
  Enrollment.toEntity(course, user)          // PENDING
  Enrollment.toWaitlistEntity(course, user)   // WAITLISTED

  // After
  Enrollment.toEntity(course, user, EnrollmentStatus.PENDING)
  Enrollment.toEntity(course, user, EnrollmentStatus.WAITLISTED)
```

### QueryDSL 개선
- `QCourse` 필드 선언 제거 → 로컬 변수로만 유지
- `QCourse.course` 직접 참조 제거 → `course` 변수를 메서드에 전달
- 빈 문자열 방어 처리 추가 (`isBlank()`)
- `searchCourses()` 파라미터를 `CourseSearchReq` DTO 로 통합

### DTO 개선
- `EnrollmentPageRes.toList()` 에 `from()` 단건 변환 메서드 분리
  - `getCourse()` 반복 호출 제거 → 변수 추출
- `CoursePageRes.toList()`, `EnrollmentPageRes.toList()` 에 페이징 로직 통합
  - 서비스의 중간 변수 제거

---

## 💡 주요 설계 결정

### `@ModelAttribute` 도입 이유
강의 목록 조회의 `@RequestParam` 이 7개로 늘어나 메서드가 길어지는 문제를 해결하기 위해 `CourseSearchReq` DTO + `@ModelAttribute` 로 전환함. `@ParameterObject` 를 함께 적용해 Swagger UI 에서도 각 파라미터가 정상적으로 노출되도록 처리
