### PR TITLE
[Refactor] 과제 A - 정책에 따른 로직 수정 및 Spring Batch 자동 취소 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/example/assignment/AssignmentApplication.java
+++ b/src/main/java/com/example/assignment/AssignmentApplication.java
@@ -3,7 +3,9 @@ package com.example.assignment;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class AssignmentApplication {

--- a/src/main/java/com/example/assignment/batch/BatchConfig.java
+++ b/src/main/java/com/example/assignment/batch/BatchConfig.java
@@ -1,0 +1,41 @@
+package com.example.assignment.batch;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BatchConfig {
+
+  private final JobLauncher jobLauncher;
+  private final Job cancelJob;
+
+  /**
+   * 미결제 자동 취소 배치
+   * 매일 자정에 실행
+   * 강의 시작 하루 전까지 결제하지 않은 PENDING 건을 자동 취소
+   */
+  @Scheduled(cron = "0 0 0 * * *")
+  public void cancelUnpaidBatch() {
+    try {
+      JobParameters jobParameters = new JobParametersBuilder()
+          .addLocalDateTime("executeTime", LocalDateTime.now())
+          .toJobParameters();
+
+      jobLauncher.run(cancelJob, jobParameters);
+      log.info("[배치] 미결제 자동 취소 배치 실행 완료");
+
+    } catch (Exception e) {
+      log.error("[배치] 미결제 자동 취소 배치 실행 실패", e);
+    }
+  }
+
+}

--- a/src/main/java/com/example/assignment/batch/BatchConfig.java
+++ b/src/main/java/com/example/assignment/batch/BatchConfig.java
@@ -31,10 +31,10 @@ public class BatchConfig {
           .toJobParameters();
 
       jobLauncher.run(cancelJob, jobParameters);
-      log.info("[배치] 미결제 자동 취소 배치 실행 완료");
+      log.info("[배치] 배치 실행 완료");
 
     } catch (Exception e) {
-      log.error("[배치] 미결제 자동 취소 배치 실행 실패", e);
+      log.error("[배치] 배치 실행 실패", e);
     }
   }
 

--- a/src/main/java/com/example/assignment/batch/job/DailyJobConfig.java
+++ b/src/main/java/com/example/assignment/batch/job/DailyJobConfig.java
@@ -1,0 +1,31 @@
+package com.example.assignment.batch.job;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class DailyJobConfig  {
+
+  private final JobRepository jobRepository;
+  private final Step cancelUnpaidStep;
+  private final Step cancelWaitlistStep;
+
+  /**
+   * 매일 자정 실행되는 수강신청 자동 취소 Job
+   * 1. cancelUnpaidStep  : 강의 시작 하루 전까지 미결제(PENDING) 건 자동 취소
+   * 2. cancelWaitlistStep : 강의 시작 3일 전까지 대기(WAITLISTED) 건 자동 취소
+   */
+  @Bean
+  public Job cancelJob() {
+    return new JobBuilder("dailyCancelEnrollmentJob", jobRepository)
+        .start(cancelUnpaidStep)
+        .next(cancelWaitlistStep)
+        .build();
+  }
+}

--- a/src/main/java/com/example/assignment/batch/listener/CancelUnpaidStepListener.java
+++ b/src/main/java/com/example/assignment/batch/listener/CancelUnpaidStepListener.java
@@ -1,0 +1,38 @@
+package com.example.assignment.batch.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CancelUnpaidStepListener implements StepExecutionListener {
+
+  @Override
+  public void beforeStep(StepExecution stepExecution) {
+    log.info("[미결제 자동 취소 배치] Step 시작 - stepName: {}",
+        stepExecution.getStepName());
+  }
+
+  @Override
+  public ExitStatus afterStep(StepExecution stepExecution) {
+    log.info("[미결제 자동 취소 배치] Step 완료" +
+            " - 처리 건수: {}" +
+            " / skip 건수: {}" +
+            " / 상태: {}",
+        stepExecution.getWriteCount(),
+        stepExecution.getSkipCount(),
+        stepExecution.getStatus()
+    );
+
+    // 예외 발생 시 로그 출력
+    stepExecution.getFailureExceptions()
+        .forEach(e ->
+            log.error("[미결제 자동 취소 배치] 예외 발생 - 예외: {}, 메시지: {}",
+                e.getClass().getSimpleName(), e.getMessage()));
+
+    return stepExecution.getExitStatus();
+  }
+}

--- a/src/main/java/com/example/assignment/batch/listener/CancelWaitlistStepListener.java
+++ b/src/main/java/com/example/assignment/batch/listener/CancelWaitlistStepListener.java
@@ -1,0 +1,38 @@
+package com.example.assignment.batch.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CancelWaitlistStepListener implements StepExecutionListener {
+
+  @Override
+  public void beforeStep(StepExecution stepExecution) {
+    log.info("[대기열 만료 배치] Step 시작 - stepName: {}",
+        stepExecution.getStepName());
+  }
+
+  @Override
+  public ExitStatus afterStep(StepExecution stepExecution) {
+    log.info("[대기열 만료 배치] Step 완료" +
+            " - 처리 건수: {}" +
+            " / skip 건수: {}" +
+            " / 상태: {}",
+        stepExecution.getWriteCount(),
+        stepExecution.getSkipCount(),
+        stepExecution.getStatus()
+    );
+
+    // 예외 발생 시 로그 출력
+    stepExecution.getFailureExceptions()
+        .forEach(e ->
+            log.error("[대기열 만료 배치] 예외 발생 - 예외: {}, 메시지: {}",
+                e.getClass().getSimpleName(), e.getMessage()));
+
+    return stepExecution.getExitStatus();
+  }
+}

--- a/src/main/java/com/example/assignment/batch/step/CancelUnpaidStepConfig.java
+++ b/src/main/java/com/example/assignment/batch/step/CancelUnpaidStepConfig.java
@@ -76,7 +76,7 @@ public class CancelUnpaidStepConfig {
    */
   @Bean
   public ItemReader<Enrollment> cancelUnpaidReader() {
-    LocalDate tomorrow = LocalDate.now().plusDays(1);
+    LocalDate tomorrow = LocalDate.now().plusDays(3);
     List<Enrollment> list = enrollmentRepository.findAllPendingBeforeCourseStart(tomorrow);
 
     return new ListItemReader<>(list);

--- a/src/main/java/com/example/assignment/batch/step/CancelUnpaidStepConfig.java
+++ b/src/main/java/com/example/assignment/batch/step/CancelUnpaidStepConfig.java
@@ -5,6 +5,7 @@ import com.example.assignment.domain.entity.Course;
 import com.example.assignment.domain.entity.Enrollment;
 import com.example.assignment.domain.repository.CourseRepository;
 import com.example.assignment.domain.repository.EnrollmentRepository;
+import com.example.assignment.domain.type.EnrollmentStatus;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -76,8 +77,11 @@ public class CancelUnpaidStepConfig {
    */
   @Bean
   public ItemReader<Enrollment> cancelUnpaidReader() {
-    LocalDate tomorrow = LocalDate.now().plusDays(3);
-    List<Enrollment> list = enrollmentRepository.findAllPendingBeforeCourseStart(tomorrow);
+    LocalDate threeDaysLater = LocalDate.now().plusDays(3);
+    List<Enrollment> list = enrollmentRepository.findAllBeforeCourseStart(
+        threeDaysLater,
+        EnrollmentStatus.PENDING
+        );
 
     return new ListItemReader<>(list);
   }

--- a/src/main/java/com/example/assignment/batch/step/CancelUnpaidStepConfig.java
+++ b/src/main/java/com/example/assignment/batch/step/CancelUnpaidStepConfig.java
@@ -1,0 +1,121 @@
+package com.example.assignment.batch.step;
+
+import com.example.assignment.batch.listener.CancelUnpaidStepListener;
+import com.example.assignment.domain.entity.Course;
+import com.example.assignment.domain.entity.Enrollment;
+import com.example.assignment.domain.repository.CourseRepository;
+import com.example.assignment.domain.repository.EnrollmentRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class CancelUnpaidStepConfig {
+
+  private final JobRepository jobRepository;
+  private final PlatformTransactionManager transactionManager;
+  private final EnrollmentRepository enrollmentRepository;
+  private final CourseRepository courseRepository;
+  private final CancelUnpaidStepListener cancelUnpaidStepListener;
+
+  @Bean
+  public Step cancelUnpaidStep() {
+    return new StepBuilder("cancelUnpaidStep", jobRepository)
+        .<Enrollment, Enrollment>chunk(100, transactionManager)
+        .reader(cancelUnpaidReader())
+        .processor(cancelUnpaidProcessor())
+        .writer(cancelUnpaidWriter())
+        .listener(cancelUnpaidStepListener)
+        .faultTolerant()
+
+        // 데이터 자체의 문제 → 해당 건 skip 후 다음 건 처리
+        .skip(NoSuchElementException.class)           // 강의 또는 수강신청 데이터가 존재하지 않는 경우
+        .skip(DataIntegrityViolationException.class)  // DB 제약 조건(PK, FK, Unique 등) 위반
+        .skip(InvalidDataAccessApiUsageException.class) // 잘못된 JPQL 또는 파라미터 사용
+        .skipLimit(10)                                // 최대 10건까지 skip 허용, 초과 시 Job 실패 처리
+
+        // 일시적인 문제 → 최대 3번 재시도 후 실패 시 skip 으로 처리
+        .retry(TransientDataAccessException.class)      // DB 일시적 오류 (연결 끊김, 세션 만료 등)
+        .retry(CannotAcquireLockException.class)        // 비관적 락 획득 실패 (동시 요청으로 인한 경합)
+        .retry(QueryTimeoutException.class)             // 쿼리 실행 시간 초과
+        .retry(DataAccessResourceFailureException.class) // DB 서버 연결 실패 (네트워크 오류 등)
+        .retry(JpaSystemException.class)                // JPA 내부 시스템 오류
+        .retryLimit(3)                                  // 최대 3번까지 재시도
+
+        // 재시도 횟수(3번) 모두 소진 시 → skip 으로 처리
+        .skip(TransientDataAccessException.class)
+        .skip(CannotAcquireLockException.class)
+        .skip(QueryTimeoutException.class)
+        .skip(DataAccessResourceFailureException.class)
+        .skip(JpaSystemException.class)
+
+        .build();
+  }
+
+  /**
+   * 강의 시작 하루 전까지 미결제(PENDING) 상태인 수강신청 건 조회
+   */
+  @Bean
+  public ItemReader<Enrollment> cancelUnpaidReader() {
+    LocalDate tomorrow = LocalDate.now().plusDays(1);
+    List<Enrollment> list = enrollmentRepository.findAllPendingBeforeCourseStart(tomorrow);
+
+    return new ListItemReader<>(list);
+  }
+
+  /**
+   * 미결제 취소 처리
+   * - 정원 복구
+   * - 대기자 자동 승격 (CLOSED → OPEN 복귀된 경우에만)
+   * - 상태 CANCELLED 로 변경
+   */
+  @Bean
+  public ItemProcessor<Enrollment, Enrollment> cancelUnpaidProcessor() {
+    return enrollment -> {
+
+      Course course = courseRepository.findByIdWithLock(enrollment.getCourse().getCourseId())
+          .orElseThrow(NoSuchElementException::new);
+
+      course.decreaseEnrollmentCnt();
+      enrollment.cancel();
+
+      // CLOSED → OPEN 으로 복귀된 경우에만 대기자 승격
+      if (course.isOpen()) {
+        enrollmentRepository.findFirstWaitlistedByCourse(course)
+            .ifPresent(waitlisted -> {
+              waitlisted.promote();
+              course.increaseEnrollmentCnt();
+            });
+      }
+
+      return enrollment;
+    };
+  }
+
+  /**
+   * 처리된 수강신청 건 저장
+   */
+  @Bean
+  public ItemWriter<Enrollment> cancelUnpaidWriter() {
+    return chunk -> enrollmentRepository.saveAll(chunk.getItems());
+  }
+}

--- a/src/main/java/com/example/assignment/batch/step/CancelWaitlistStepConfig.java
+++ b/src/main/java/com/example/assignment/batch/step/CancelWaitlistStepConfig.java
@@ -1,0 +1,96 @@
+package com.example.assignment.batch.step;
+
+import com.example.assignment.batch.listener.CancelWaitlistStepListener;
+import com.example.assignment.domain.entity.Enrollment;
+import com.example.assignment.domain.repository.EnrollmentRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class CancelWaitlistStepConfig  {
+
+  private final JobRepository jobRepository;
+  private final PlatformTransactionManager transactionManager;
+  private final EnrollmentRepository enrollmentRepository;
+  private final CancelWaitlistStepListener cancelWaitlistStepListener;
+
+  @Bean
+  public Step cancelWaitlistStep() {
+    return new StepBuilder("cancelWaitlistStep", jobRepository)
+        .<Enrollment, Enrollment>chunk(100, transactionManager)
+        .reader(cancelWaitlistReader())
+        .processor(cancelWaitlistProcessor())
+        .writer(cancelWaitlistWriter())
+        .listener(cancelWaitlistStepListener)
+        .faultTolerant()
+
+        // 데이터 자체의 문제 → 해당 건 skip 후 다음 건 처리
+        .skip(DataIntegrityViolationException.class)    // DB 제약 조건(PK, FK, Unique 등) 위반
+        .skip(InvalidDataAccessApiUsageException.class) // 잘못된 JPQL 또는 파라미터 사용
+        .skipLimit(10)                                  // 최대 10건까지 skip 허용, 초과 시 Job 실패 처리
+
+        // 일시적인 문제 → 최대 3번 재시도 후 실패 시 skip 으로 처리
+        .retry(TransientDataAccessException.class)       // DB 일시적 오류 (연결 끊김, 세션 만료 등)
+        .retry(QueryTimeoutException.class)              // 쿼리 실행 시간 초과
+        .retry(DataAccessResourceFailureException.class) // DB 서버 연결 실패 (네트워크 오류 등)
+        .retry(JpaSystemException.class)                 // JPA 내부 시스템 오류
+        .retryLimit(3)                                   // 최대 3번까지 재시도
+
+        // 재시도 횟수(3번) 모두 소진 시 → skip 으로 처리
+        .skip(TransientDataAccessException.class)
+        .skip(QueryTimeoutException.class)
+        .skip(DataAccessResourceFailureException.class)
+        .skip(JpaSystemException.class)
+
+        .build();
+  }
+
+  /**
+   * 강의 시작 3일 전까지 대기(WAITLISTED) 상태인 수강신청 건 조회
+   */
+  @Bean
+  public ItemReader<Enrollment> cancelWaitlistReader() {
+    LocalDate threeDaysLater = LocalDate.now().plusDays(3);
+    List<Enrollment> list = enrollmentRepository.findAllWaitlistedBeforeCourseStart(threeDaysLater);
+
+    return new ListItemReader<>(list);
+  }
+
+  /**
+   * 대기열 만료 취소 처리
+   * 정원을 차지하지 않으므로 정원 복구 없이 상태만 변경
+   */
+  @Bean
+  public ItemProcessor<Enrollment, Enrollment> cancelWaitlistProcessor() {
+    return enrollment -> {
+      enrollment.cancel();
+      return enrollment;
+    };
+  }
+
+  /**
+   * 처리된 수강신청 건 저장
+   */
+  @Bean
+  public ItemWriter<Enrollment> cancelWaitlistWriter() {
+    return chunk -> enrollmentRepository.saveAll(chunk.getItems());
+  }
+}

--- a/src/main/java/com/example/assignment/batch/step/CancelWaitlistStepConfig.java
+++ b/src/main/java/com/example/assignment/batch/step/CancelWaitlistStepConfig.java
@@ -3,6 +3,7 @@ package com.example.assignment.batch.step;
 import com.example.assignment.batch.listener.CancelWaitlistStepListener;
 import com.example.assignment.domain.entity.Enrollment;
 import com.example.assignment.domain.repository.EnrollmentRepository;
+import com.example.assignment.domain.type.EnrollmentStatus;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -69,7 +70,10 @@ public class CancelWaitlistStepConfig  {
   @Bean
   public ItemReader<Enrollment> cancelWaitlistReader() {
     LocalDate threeDaysLater = LocalDate.now().plusDays(3);
-    List<Enrollment> list = enrollmentRepository.findAllWaitlistedBeforeCourseStart(threeDaysLater);
+    List<Enrollment> list = enrollmentRepository.findAllBeforeCourseStart(
+        threeDaysLater,
+        EnrollmentStatus.WAITLISTED
+    );
 
     return new ListItemReader<>(list);
   }

--- a/src/main/java/com/example/assignment/domain/entity/Enrollment.java
+++ b/src/main/java/com/example/assignment/domain/entity/Enrollment.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -90,7 +91,9 @@ public class Enrollment extends BaseEntity {
   /**
    * 취소 가능 여부 확인
    * - PENDING, WAITLISTED: 결제 전이므로 언제든 취소 가능
-   * - CONFIRMED: 결제 완료 시점(updatedAt) 기준 7일 이내만 취소 가능
+   * - CONFIRMED: 아래 두 조건을 모두 만족하는 경우에만 취소 가능
+   *   1. 결제 완료 시점(updatedAt) 기준 7일 이내
+   *   2. 강의 시작 하루 전까지
    * - CANCELLED: 취소 불가 (false 반환)
    */
   public boolean isCancellable() {
@@ -99,9 +102,15 @@ public class Enrollment extends BaseEntity {
       return true;
     }
     if (this.enrollmentStatus == EnrollmentStatus.CONFIRMED) {
-      return this.getUpdatedAt()
+      boolean withinDeadline = this.getUpdatedAt()
           .plusDays(7)
           .isAfter(LocalDateTime.now());
+
+      boolean beforeCourseStart = this.course.getStartPeriodAt()
+          .minusDays(1)
+          .isAfter(LocalDate.now());
+
+      return withinDeadline && beforeCourseStart;
     }
     return false;
   }

--- a/src/main/java/com/example/assignment/domain/entity/Enrollment.java
+++ b/src/main/java/com/example/assignment/domain/entity/Enrollment.java
@@ -107,7 +107,7 @@ public class Enrollment extends BaseEntity {
           .isAfter(LocalDateTime.now());
 
       boolean beforeCourseStart = this.course.getStartPeriodAt()
-          .minusDays(1)
+          .minusDays(3)
           .isAfter(LocalDate.now());
 
       return withinDeadline && beforeCourseStart;

--- a/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
@@ -4,6 +4,7 @@ import com.example.assignment.domain.entity.Course;
 import com.example.assignment.domain.entity.Enrollment;
 import com.example.assignment.domain.entity.User;
 import com.example.assignment.domain.type.EnrollmentStatus;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -40,4 +41,30 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     LIMIT 1
     """)
   Optional<Enrollment> findFirstWaitlistedByCourse(@Param("course") Course course);
+
+  @Query("""
+    SELECT e FROM Enrollment e
+    JOIN FETCH e.course
+    WHERE e.enrollmentId = :enrollmentId
+    """)
+  Optional<Enrollment> findByIdWithCourse(@Param("enrollmentId") Long enrollmentId);
+
+  @Query("""
+    SELECT e FROM Enrollment e
+    JOIN FETCH e.course
+    WHERE e.enrollmentStatus = 'PENDING'
+      AND e.course.startPeriodAt <= :tomorrow
+    """)
+  List<Enrollment> findAllPendingBeforeCourseStart(@Param("tomorrow") LocalDate tomorrow);
+
+  @Query("""
+    SELECT e FROM Enrollment e
+    JOIN FETCH e.course
+    WHERE e.enrollmentStatus = 'WAITLISTED'
+      AND e.course.startPeriodAt <= :threeDaysLater
+    """)
+  List<Enrollment> findAllWaitlistedBeforeCourseStart(@Param("threeDaysLater") LocalDate threeDaysLater);
+
+
+
 }

--- a/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/EnrollmentRepository.java
@@ -52,18 +52,13 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
   @Query("""
     SELECT e FROM Enrollment e
     JOIN FETCH e.course
-    WHERE e.enrollmentStatus = 'PENDING'
-      AND e.course.startPeriodAt <= :tomorrow
-    """)
-  List<Enrollment> findAllPendingBeforeCourseStart(@Param("tomorrow") LocalDate tomorrow);
-
-  @Query("""
-    SELECT e FROM Enrollment e
-    JOIN FETCH e.course
-    WHERE e.enrollmentStatus = 'WAITLISTED'
+    WHERE e.enrollmentStatus = :status
       AND e.course.startPeriodAt <= :threeDaysLater
     """)
-  List<Enrollment> findAllWaitlistedBeforeCourseStart(@Param("threeDaysLater") LocalDate threeDaysLater);
+  List<Enrollment> findAllBeforeCourseStart(
+      @Param("threeDaysLater") LocalDate threeDaysLater,
+      @Param("status") EnrollmentStatus status
+      );
 
 
 

--- a/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
@@ -141,7 +141,7 @@ public class EnrollmentServiceImpl implements EnrollmentService {
   @Transactional
   public ResultResponse cancelEnrollment(Long userId, Long enrollmentId) {
 
-    Enrollment enrollment = getEnrollment(enrollmentId);
+    Enrollment enrollment = getEnrollmentWithCourse(enrollmentId);
 
     if (enrollment.isNotOwnedBy(userId)) {
       throw new GlobalException(FailedType.ACCESS_DENIED);
@@ -183,6 +183,12 @@ public class EnrollmentServiceImpl implements EnrollmentService {
 
   private Enrollment getEnrollment(Long enrollmentId) {
     return enrollmentRepository.findById(enrollmentId)
+        .orElseThrow(() -> new GlobalException(FailedType.ENROLLMENT_NOT_FOUND));
+  }
+
+  // course 포함 조회 (취소 시 사용)
+  private Enrollment getEnrollmentWithCourse(Long enrollmentId) {
+    return enrollmentRepository.findByIdWithCourse(enrollmentId)
         .orElseThrow(() -> new GlobalException(FailedType.ENROLLMENT_NOT_FOUND));
   }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,14 +16,11 @@ spring:
     properties:
       hibernate:
         format_sql: true
-    show-sql: true
+    show-sql: false
     open-in-view: false
 
-
-  jackson:
-    time-zone: Asia/Seoul
-
-
-logging:
-  level:
-    com.example.notification: DEBUG
+  batch:
+    job:
+      enabled: false
+    jdbc:
+      initialize-schema: always

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,10 +20,8 @@ spring:
     open-in-view: false
 
 
-  jackson:
-    time-zone: Asia/Seoul
-
-
-logging:
-  level:
-    com.example.notification: DEBUG
+  batch:
+    job:
+      enabled: false
+    jdbc:
+      initialize-schema: always


### PR DESCRIPTION
## 작업 내용
> 서비스 정책에 맞게 취소 로직을 수정하고, 미결제 자동 취소 및 대기열 만료 자동 취소를 Spring Batch 로 구현

## 주요 변경사항

### 취소 정책 로직 수정 (`Enrollment.isCancellable()`)

기존에 결제 후 7일 이내 조건만 체크하던 로직에 강의 시작 3일 전 조건을 추가함.

```
Before: 결제 후 7일 이내만 취소 가능
After:  결제 후 7일 이내 AND 강의 시작 3일 전까지 모두 만족해야 취소 가능
```

```java
boolean withinDeadline = this.getUpdatedAt().plusDays(7).isAfter(LocalDateTime.now());
boolean beforeCourseStart = this.course.getStartPeriodAt().minusDays(1).isAfter(LocalDate.now());
return withinDeadline && beforeCourseStart;
```

### `getEnrollmentWithCourse()` 추가

`isCancellable()` 에서 `course.getStartPeriodAt()` 접근이 필요하여 `cancelEnrollment()` 에서 `course` 를 fetchJoin 으로 함께 조회하도록 변경함.

```java
// cancelEnrollment() 에서
Enrollment enrollment = getEnrollmentWithCourse(enrollmentId);  // course fetchJoin
```
## 

### Spring Batch 구현

**패키지 구조**
```
batch
 ├── BatchConfig.java              (스케줄러 - 매일 자정 실행)
 ├── job
 │    └── DailyJobConfig.java      (Job 정의)
 ├── step
 │    ├── CancelUnpaidStepConfig.java   (미결제 자동 취소 Step)
 │    └── CancelWaitlistStepConfig.java (대기열 만료 자동 취소 Step)
 └── listener
      ├── CancelUnpaidStepListener.java  (미결제 Step 로그)
      └── CancelWaitlistStepListener.java (대기열 Step 로그)
```

**DailyJobConfig — 매일 자정 실행되는 Job**
```
1. cancelUnpaidStep  : 강의 시작 3일 전까지 미결제(PENDING) 건 자동 취소
2. cancelWaitlistStep: 강의 시작 3일 전까지 대기(WAITLISTED) 건 자동 취소
```

**예외 처리 전략**

| 구분 | 예외 | 처리 방식 |
```
데이터 문제 skip (최대 10건) : 
- `NoSuchElementException`
- `DataIntegrityViolationException`
- `InvalidDataAccessApiUsageException` 

일시적 문제 retry 3회 후 skip :
- `TransientDataAccessException`
- `CannotAcquireLockException`
- `QueryTimeoutException`
- `DataAccessResourceFailureException`
- `JpaSystemException` 
```
**StepListener — 실행 결과 로그**
```
[미결제 자동 취소 배치] Step 시작 - stepName: cancelUnpaidStep
[미결제 자동 취소 배치] Step 완료 - 처리 건수: 2 / skip 건수: 0 / 상태: COMPLETED
```

### Repository 쿼리 추가

```java
// course fetchJoin 으로 Enrollment 조회 (취소 시 LazyInitializationException 방지)
Optional findByIdWithCourse(Long enrollmentId);

// 강의 시작 3일 전까지 대기 건 조회
List findAllBeforeCourseStart(LocalDate threeDaysLater, EnrollmentStatus status);
```
## 
## 배치 실행 흐름

```
매일 자정 (0 0 0 * * *)
    ↓
BatchConfig.cancelUnpaidBatch() 실행
    ↓
DailyJobConfig.cancelJob()
    ├── cancelUnpaidStep
    │    ├── Reader    : PENDING 건 중 강의 시작 하루 전인 건 조회
    │    ├── Processor : 정원 복구 + 대기자 승격 + 상태 CANCELLED 변경
    │    └── Writer    : DB 저장
    │
    └── cancelWaitlistStep
         ├── Reader    : WAITLISTED 건 중 강의 시작 3일 전인 건 조회
         ├── Processor : 상태 CANCELLED 변경 (정원 복구 없음)
         └── Writer    : DB 저장
```