### PR TITLE
[Feat] 과제 A - 강의 자동 마감 배치 구현 및 취소 정책 로직 개선

### DIFF
--- a/src/main/java/com/example/assignment/batch/job/DailyJobConfig.java
+++ b/src/main/java/com/example/assignment/batch/job/DailyJobConfig.java
@@ -15,6 +15,7 @@ public class DailyJobConfig  {
   private final JobRepository jobRepository;
   private final Step cancelUnpaidStep;
   private final Step cancelWaitlistStep;
+  private final Step closeCourseStep;
 
   /**
    * 매일 자정 실행되는 수강신청 자동 취소 Job
@@ -24,7 +25,8 @@ public class DailyJobConfig  {
   @Bean
   public Job cancelJob() {
     return new JobBuilder("dailyCancelEnrollmentJob", jobRepository)
-        .start(cancelUnpaidStep)
+        .start(closeCourseStep)
+        .next(cancelUnpaidStep)
         .next(cancelWaitlistStep)
         .build();
   }

--- a/src/main/java/com/example/assignment/batch/listener/CloseCourseStepListener.java
+++ b/src/main/java/com/example/assignment/batch/listener/CloseCourseStepListener.java
@@ -1,0 +1,37 @@
+package com.example.assignment.batch.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CloseCourseStepListener implements StepExecutionListener {
+
+  @Override
+  public void beforeStep(StepExecution stepExecution) {
+    log.info("[강의 자동 마감 배치] Step 시작 - stepName: {}",
+        stepExecution.getStepName());
+  }
+
+  @Override
+  public ExitStatus afterStep(StepExecution stepExecution) {
+    log.info("[강의 자동 마감 배치] Step 완료" +
+            " - 처리 건수: {}" +
+            " / skip 건수: {}" +
+            " / 상태: {}",
+        stepExecution.getWriteCount(),
+        stepExecution.getSkipCount(),
+        stepExecution.getStatus()
+    );
+
+    stepExecution.getFailureExceptions()
+        .forEach(e ->
+            log.error("[강의 자동 마감 배치] 예외 발생 - 예외: {}, 메시지: {}",
+                e.getClass().getSimpleName(), e.getMessage()));
+
+    return stepExecution.getExitStatus();
+  }
+}

--- a/src/main/java/com/example/assignment/batch/step/CloseCourseStepConfig.java
+++ b/src/main/java/com/example/assignment/batch/step/CloseCourseStepConfig.java
@@ -71,8 +71,8 @@ public class CloseCourseStepConfig {
    */
   @Bean
   public ItemReader<Course> closeCourseReader() {
-    LocalDate tomorrow = LocalDate.now().plusDays(1);
-    List<Course> list = courseRepository.findAllOpenOrDraftCoursesBeforeStart(tomorrow);
+    LocalDate threeDaysLater = LocalDate.now().plusDays(3);
+    List<Course> list = courseRepository.findAllOpenOrDraftCoursesBeforeStart(threeDaysLater);
     return new ListItemReader<>(list);
   }
 

--- a/src/main/java/com/example/assignment/batch/step/CloseCourseStepConfig.java
+++ b/src/main/java/com/example/assignment/batch/step/CloseCourseStepConfig.java
@@ -1,0 +1,98 @@
+package com.example.assignment.batch.step;
+
+import com.example.assignment.batch.listener.CloseCourseStepListener;
+import com.example.assignment.domain.entity.Course;
+import com.example.assignment.domain.repository.CourseRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.transaction.PlatformTransactionManager;
+
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class CloseCourseStepConfig {
+
+  private final JobRepository jobRepository;
+  private final PlatformTransactionManager transactionManager;
+  private final CourseRepository courseRepository;
+  private final CloseCourseStepListener closeCourseStepListener;
+
+  @Bean
+  public Step closeCourseStep() {
+    return new StepBuilder("closeCourseStep", jobRepository)
+        .<Course, Course>chunk(100, transactionManager)
+        .reader(closeCourseReader())
+        .processor(closeCourseProcessor())
+        .writer(closeCourseWriter())
+        .listener(closeCourseStepListener)
+        .faultTolerant()
+
+        // 데이터 자체의 문제 → 해당 건 skip 후 다음 건 처리
+        .skip(DataIntegrityViolationException.class)    // DB 제약 조건 위반
+        .skip(InvalidDataAccessApiUsageException.class) // 잘못된 JPQL 또는 파라미터 사용
+        .skipLimit(10)                                  // 최대 10건까지 skip 허용
+
+        // 일시적인 문제 → 최대 3번 재시도 후 실패 시 skip 으로 처리
+        .retry(TransientDataAccessException.class)       // DB 일시적 오류
+        .retry(QueryTimeoutException.class)              // 쿼리 실행 시간 초과
+        .retry(DataAccessResourceFailureException.class) // DB 서버 연결 실패
+        .retry(JpaSystemException.class)                 // JPA 내부 시스템 오류
+        .retryLimit(3)
+
+        // 재시도 횟수(3번) 모두 소진 시 → skip 으로 처리
+        .skip(TransientDataAccessException.class)
+        .skip(QueryTimeoutException.class)
+        .skip(DataAccessResourceFailureException.class)
+        .skip(JpaSystemException.class)
+
+        .build();
+  }
+
+  /**
+   * 강의 시작 하루 전까지 OPEN 또는 DRAFT 상태인 강의 조회
+   */
+  @Bean
+  public ItemReader<Course> closeCourseReader() {
+    LocalDate tomorrow = LocalDate.now().plusDays(1);
+    List<Course> list = courseRepository.findAllOpenOrDraftCoursesBeforeStart(tomorrow);
+    return new ListItemReader<>(list);
+  }
+
+  /**
+   * 강의 자동 마감 처리
+   * - OPEN, DRAFT 상태인 강의를 CLOSED 로 변경
+   */
+  @Bean
+  public ItemProcessor<Course, Course> closeCourseProcessor() {
+    return course -> {
+      course.closeCourse();
+      return course;
+    };
+  }
+
+  /**
+   * 처리된 강의 저장
+   */
+  @Bean
+  public ItemWriter<Course> closeCourseWriter() {
+    return chunk -> courseRepository.saveAll(chunk.getItems());
+  }
+}

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -149,7 +149,7 @@ public class Course extends BaseEntity {
    * 수강 인원 감소
    * 수강 취소 시 호출
    * CLOSED 상태에서 자리가 생기면 자동으로 OPEN 으로 복귀
-   * 단, 강의 시작 하루 전인 경우에는 OPEN 으로 복귀하지 않음
+   * 단, 강의 시작 3일 전인 경우에는 OPEN 으로 복귀하지 않음
    */
   public void decreaseEnrollmentCnt() {
     if (this.enrollmentCnt > 0) {
@@ -157,7 +157,7 @@ public class Course extends BaseEntity {
     }
     if (this.courseStatus == CourseStatus.CLOSED
         && !this.isFull()
-        && this.startPeriodAt.isAfter(LocalDate.now().plusDays(1))) {
+        && this.startPeriodAt.isAfter(LocalDate.now().plusDays(3))) {
       this.courseStatus = CourseStatus.OPEN;
     }
   }

--- a/src/main/java/com/example/assignment/domain/entity/Course.java
+++ b/src/main/java/com/example/assignment/domain/entity/Course.java
@@ -147,14 +147,17 @@ public class Course extends BaseEntity {
 
   /**
    * 수강 인원 감소
-   * 수강 취소 또는 대기자 승격 실패 시 호출
+   * 수강 취소 시 호출
    * CLOSED 상태에서 자리가 생기면 자동으로 OPEN 으로 복귀
+   * 단, 강의 시작 하루 전인 경우에는 OPEN 으로 복귀하지 않음
    */
   public void decreaseEnrollmentCnt() {
     if (this.enrollmentCnt > 0) {
       this.enrollmentCnt--;
     }
-    if (this.courseStatus == CourseStatus.CLOSED && !this.isFull()) {
+    if (this.courseStatus == CourseStatus.CLOSED
+        && !this.isFull()
+        && this.startPeriodAt.isAfter(LocalDate.now().plusDays(1))) {
       this.courseStatus = CourseStatus.OPEN;
     }
   }

--- a/src/main/java/com/example/assignment/domain/repository/CourseRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/CourseRepository.java
@@ -5,6 +5,7 @@ import com.example.assignment.domain.entity.User;
 import com.example.assignment.domain.type.CourseStatus;
 import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -41,4 +42,11 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT c FROM Course c WHERE c.courseId = :courseId")
   Optional<Course> findByIdWithLock(@Param("courseId") Long courseId);
+
+  @Query("""
+    SELECT c FROM Course c
+    WHERE c.courseStatus IN ('OPEN', 'DRAFT')
+      AND c.startPeriodAt <= :tomorrow
+    """)
+  List<Course> findAllOpenOrDraftCoursesBeforeStart(@Param("tomorrow") LocalDate tomorrow);
 }

--- a/src/main/java/com/example/assignment/domain/repository/CourseRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/CourseRepository.java
@@ -46,7 +46,7 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
   @Query("""
     SELECT c FROM Course c
     WHERE c.courseStatus IN ('OPEN', 'DRAFT')
-      AND c.startPeriodAt <= :tomorrow
+      AND c.startPeriodAt <= :threeDaysLater
     """)
-  List<Course> findAllOpenOrDraftCoursesBeforeStart(@Param("tomorrow") LocalDate tomorrow);
+  List<Course> findAllOpenOrDraftCoursesBeforeStart(@Param("threeDaysLater") LocalDate threeDaysLater);
 }

--- a/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
@@ -164,7 +164,10 @@ public class EnrollmentServiceImpl implements EnrollmentService {
 
     course.decreaseEnrollmentCnt();
     enrollment.cancel();
-    promoteNextFromWaitlist(course);
+
+    if(course.isOpen()) {
+      promoteNextFromWaitlist(course);
+    }
 
     return ResultResponse.of(SuccessType.SUCCESS_CANCEL_ENROLLMENT);
   }


### PR DESCRIPTION
## 작업 내용
강의 시작 3일 전 자동 마감 처리를 Spring Batch 로 구현하고, 취소 발생 시 강의 상태 복귀 조건을 정책에 맞게 수정함.

## 주요 변경사항

### 강의 자동 마감 Step 추가 (`CloseCourseStepConfig`)

강의 시작 하루 전 `OPEN` 또는 `DRAFT` 상태인 강의를 자동으로 `CLOSED` 로 변경하는 Step 을 추가함.

- `closeCourseReader` : 강의 시작일이 현재 날짜 기준 3일 이전이고 `OPEN` 또는 `DRAFT` 상태인 강의 조회
- `closeCourseProcessor` : `closeCourse()` 호출로 상태를 `CLOSED` 로 변경
- `closeCourseWriter` : 처리된 강의 저장
- `CloseCourseStepListener` : Step 시작 / 완료 / 예외 발생 시 로그 출력

### DailyJob Step 순서 변경

강의 마감을 먼저 처리한 후 미결제 취소 → 대기열 만료 순으로 실행하도록 변경함.

```
Before: cancelUnpaidStep → cancelWaitlistStep
After:  closeCourseStep → cancelUnpaidStep → cancelWaitlistStep
```

강의 마감을 먼저 처리해야 이후 미결제 취소, 대기열 만료가 올바른 강의 상태를 기준으로 동작함.

### `decreaseEnrollmentCnt()` 조건 추가

취소 발생 시 강의가 자동으로 `OPEN` 으로 복귀되는 로직에 강의 시작 3일 전 조건을 추가함.

```java
// Before
if (this.courseStatus == CourseStatus.CLOSED && !this.isFull()) {
    this.courseStatus = CourseStatus.OPEN;
}

// After
if (this.courseStatus == CourseStatus.CLOSED
    && !this.isFull()
    && this.startPeriodAt.isAfter(LocalDate.now().plusDays(1))) {
    this.courseStatus = CourseStatus.OPEN;
}
```

강의 시작 3일 전이라면 취소로 자리가 생겨도 `OPEN` 으로 복귀하지 않음.

### `cancelEnrollment()` 대기자 승격 조건 추가

취소 후 `isOpen()` 체크를 추가하여 강의가 `OPEN` 상태인 경우에만 대기자를 승격하도록 변경함.

```java
course.decreaseEnrollmentCnt();
enrollment.cancel();

// Before
promoteNextFromWaitlist(course);

// After
if (course.isOpen()) {
    promoteNextFromWaitlist(course);
}
```

강의 시작 3일 전 취소 발생 시 `OPEN` 으로 복귀되지 않으므로 대기자 승격도 하지 않음.

### `CourseRepository` 쿼리 추가

```java
// 강의 시작 3일 전까지 OPEN 또는 DRAFT 상태인 강의 조회
List findAllOpenOrDraftCoursesBeforeStart(LocalDate tomorrow);
```

---

## 배치 실행 흐름

```
매일 자정
    ↓
closeCourseStep
    → 강의 시작 3일 전 OPEN/DRAFT 강의 → CLOSED 자동 마감
    ↓
cancelUnpaidStep
    → 강의 시작 3일 전 미결제(PENDING) 건 자동 취소 + 대기자 승격
    ↓
cancelWaitlistStep
    → 강의 시작 3일 전 대기(WAITLISTED) 건 자동 취소
```
