### PR TITLE
[Fix] 과제 A - API 테스트 이후 발견된 버그 수정

### DIFF
--- a/src/main/java/com/example/assignment/domain/dto/request/CourseReq.java
+++ b/src/main/java/com/example/assignment/domain/dto/request/CourseReq.java
@@ -27,6 +27,7 @@ public class CourseReq {
 
   @Schema(example = "50000")
   @NotNull(message = "강의 가격을 입력해주세요.")
+  @Min(value = 0, message = "강의 가격은 0원 이상이어야 합니다.")
   private Long amount;
 
   @Schema(example = "30")

--- a/src/main/java/com/example/assignment/domain/repository/querydsl/CourseQueryRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/querydsl/CourseQueryRepository.java
@@ -8,6 +8,7 @@ import com.example.assignment.domain.entity.User;
 import com.example.assignment.domain.type.CourseStatus;
 import com.example.assignment.domain.type.UserRole;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
@@ -39,6 +40,13 @@ public class CourseQueryRepository {
             startPeriodAtGoe(course, searchReq.getStartPeriodAt()),
             endPeriodAtLoe(course, searchReq.getEndPeriodAt()),
             courseStatusEq(course, searchReq.getCourseStatus())
+        )
+        .orderBy(
+            Expressions.cases()
+                .when(course.courseStatus.eq(CourseStatus.OPEN)).then(1)
+                .when(course.courseStatus.eq(CourseStatus.DRAFT)).then(2)
+                .otherwise(3).asc(),
+            course.startPeriodAt.asc()
         )
         .fetch();
   }

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -33,6 +33,7 @@ public enum FailedType {
   // =================== 결제 ===================
   ALREADY_PAID(HttpStatus.CONFLICT, "이미 결제가 완료된 수강신청입니다."),
   ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 수강신청입니다."),
+  WAITLISTED_CANNOT_PAY(HttpStatus.BAD_REQUEST, "대기 중인 수강신청은 결제할 수 없습니다."),
 
   // =================== 전역 예외 ===================
   INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "올바르지 않은 입력값입니다."),

--- a/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/EnrollmentServiceImpl.java
@@ -92,6 +92,10 @@ public class EnrollmentServiceImpl implements EnrollmentService {
       throw new GlobalException(FailedType.ACCESS_DENIED);
     }
 
+    if (enrollment.isWaitlisted()) {
+      throw new GlobalException(FailedType.WAITLISTED_CANNOT_PAY);
+    }
+
     if (enrollment.isConfirmed()) {
       throw new GlobalException(FailedType.ALREADY_PAID);
     }


### PR DESCRIPTION
## 작업 내용
> 테스트 과정에서 발견된 버그 2건을 수정하고, 강의 목록 정렬 기준을 추가함.

## 주요 변경사항

### WAITLISTED 상태에서 결제 불가 처리 (`payEnrollment()`)

기존에 `WAITLISTED` 상태 체크가 없어 대기 중인 수강신청도 결제 확정이 가능한 버그를 수정함.

```java
// Before - WAITLISTED 체크 없음
if (enrollment.isConfirmed()) throw ...;
if (enrollment.isCancelled()) throw ...;

// After - WAITLISTED 체크 추가
if (enrollment.isWaitlisted()) {
    throw new GlobalException(FailedType.WAITLISTED_CANNOT_PAY);
}
if (enrollment.isConfirmed()) throw ...;
if (enrollment.isCancelled()) throw ...;
```

### 음수 강의 가격 등록 방지 (`CourseReq`)

`amount` 필드에 `@Min(value = 0)` 검증이 없어 음수 가격으로 강의 등록이 가능한 버그를 수정함.

```java
@Schema(example = "50000")
@NotNull(message = "강의 가격을 입력해주세요.")
@Min(value = 0, message = "강의 가격은 0원 이상이어야 합니다.")  // 추가
private Long amount;
```

### 강의 목록 정렬 기준 추가 (`CourseQueryRepository`)

기존에 정렬 기준이 없어 대량 데이터에서 순서 보장이 안 되는 문제를 수정함.

```
정렬 기준
1순위: 강의 상태 (OPEN → DRAFT → CLOSED)
2순위: 강의 시작일 오름차순