### PR TITLE
Feat/#41/sale record list

### DIFF
--- a/src/main/java/com/example/assignment/controller/CreatorController.java
+++ b/src/main/java/com/example/assignment/controller/CreatorController.java
@@ -1,0 +1,33 @@
+package com.example.assignment.controller;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import com.example.assignment.service.CreatorService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "강사 API", description = "정산 집계 내역 조회")
+@RestController
+@RequestMapping("/api/v1/creator")
+@RequiredArgsConstructor
+public class CreatorController {
+
+  private final CreatorService creatorService;
+
+  @GetMapping("/{userId}/sale")
+  @Operation(summary = "월 별 정산 집계 내역 조회", description = "기간, 상태로 필터링 가능.")
+  public ResponseEntity<ResultResponse> getSaleRecord(
+      @PathVariable Long userId,
+      @RequestParam(required = false) String yearMonth) {
+
+    ResultResponse response = creatorService.getSaleRecord(userId, yearMonth);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+}

--- a/src/main/java/com/example/assignment/domain/dto/response/SettlementRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/SettlementRes.java
@@ -1,0 +1,58 @@
+package com.example.assignment.domain.dto.response;
+
+import com.example.assignment.domain.entity.Settlement;
+import java.text.NumberFormat;
+import java.util.Locale;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SettlementRes {
+
+  private static final NumberFormat FORMAT = NumberFormat.getInstance(Locale.KOREA);
+
+  private Long settlementId;
+
+  private Long userId;
+
+  private String totalAmount;       // 총 판매 금액
+
+  private String refundAmount;      // 환불 금액
+
+  private String netAmount;         // 순 판매 금액
+
+  private String commission;        // 플랫폼 수수료
+
+  private String settlementAmount;  // 정산 예정 금액
+
+  private String saleCount;           // 판매 건수
+
+  private String cancelCount;         // 취소 건수
+
+
+  private String settlementStatus;
+
+  private String settlementMonth;
+
+
+  public static SettlementRes toResponse(Settlement settlement) {
+    return SettlementRes.builder()
+        .settlementId(settlement.getSettlementId())
+        .userId(settlement.getUser().getUserId())
+        .totalAmount(FORMAT.format(settlement.getTotalAmount()) + "원")
+        .refundAmount(FORMAT.format(settlement.getRefundAmount()) + "원")
+        .netAmount(FORMAT.format(settlement.getNetAmount()) + "원")
+        .commission(FORMAT.format(settlement.getCommission()) + "원")
+        .settlementAmount(FORMAT.format(settlement.getSettlementAmount()) + "원")
+        .saleCount(settlement.getSaleCount() + "건")
+        .cancelCount(settlement.getCancelCount() + "건")
+        .settlementStatus(settlement.getSettlementStatus().getValue())
+        .settlementMonth(settlement.getSettlementMonth())
+        .build();
+  }
+}

--- a/src/main/java/com/example/assignment/domain/dto/response/SettlementSummary.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/SettlementSummary.java
@@ -1,0 +1,20 @@
+package com.example.assignment.domain.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SettlementSummary {
+
+  private Long totalAmount;
+
+  private Long refundAmount;
+
+  private Long saleCount;
+
+  private Long cancelCount;
+
+}

--- a/src/main/java/com/example/assignment/domain/entity/SaleRecord.java
+++ b/src/main/java/com/example/assignment/domain/entity/SaleRecord.java
@@ -29,6 +29,10 @@ public class SaleRecord extends BaseEntity {
   @JoinColumn(name = "enrollment_id", nullable = false)
   private Enrollment enrollment;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
   private Long amount;
 
   private Long refundAmount;
@@ -36,6 +40,7 @@ public class SaleRecord extends BaseEntity {
   public static SaleRecord toEntity(Enrollment enrollment) {
     return SaleRecord.builder()
         .enrollment(enrollment)
+        .user(enrollment.getCourse().getUser())
         .amount(enrollment.getCourse().getAmount())
         .build();
   }

--- a/src/main/java/com/example/assignment/domain/entity/Settlement.java
+++ b/src/main/java/com/example/assignment/domain/entity/Settlement.java
@@ -1,0 +1,118 @@
+package com.example.assignment.domain.entity;
+
+import com.example.assignment.domain.dto.response.SettlementSummary;
+import com.example.assignment.domain.type.SettlementStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.YearMonth;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Settlement {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long settlementId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  private Long totalAmount;       // 총 판매 금액
+  private Long refundAmount;      // 환불 금액
+  private Long netAmount;         // 순 판매 금액
+  private Long commission;        // 플랫폼 수수료
+  private Long settlementAmount;  // 정산 예정 금액
+  private Long saleCount;         // 판매 건수
+  private Long cancelCount;       // 취소 건수
+
+  @Enumerated(EnumType.STRING)
+  private SettlementStatus settlementStatus;
+
+  private String settlementMonth;
+
+  // =================== 정적 팩토리 메서드 ===================
+
+  /**
+   * Settlement 생성
+   * 집계 데이터를 기반으로 정산 금액을 계산하여 PENDING 상태로 생성
+   */
+  public static Settlement toEntity(User user, YearMonth yearMonth, SettlementSummary summary) {
+    long[] calculated = calculate(summary);
+
+    return Settlement.builder()
+        .user(user)
+        .totalAmount(calculated[0])
+        .refundAmount(calculated[1])
+        .netAmount(calculated[2])
+        .commission(calculated[3])
+        .settlementAmount(calculated[4])
+        .saleCount(summary.getSaleCount() == null ? 0L : summary.getSaleCount())
+        .cancelCount(summary.getCancelCount() == null ? 0L : summary.getCancelCount())
+        .settlementStatus(SettlementStatus.PENDING)
+        .settlementMonth(yearMonth.toString())
+        .build();
+  }
+
+  // =================== 정산 갱신 ===================
+
+  /**
+   * 정산 데이터 갱신
+   * PENDING 상태일 때 취소 발생 시 최신 집계 데이터로 업데이트
+   * 호출 전 isPending() 확인은 서비스 레이어에서 담당
+   */
+  public void update(SettlementSummary summary) {
+    long[] calculated = calculate(summary);
+
+    this.totalAmount      = calculated[0];
+    this.refundAmount     = calculated[1];
+    this.netAmount        = calculated[2];
+    this.commission       = calculated[3];
+    this.settlementAmount = calculated[4];
+    this.saleCount        = summary.getSaleCount() == null ? 0L : summary.getSaleCount();
+    this.cancelCount      = summary.getCancelCount() == null ? 0L : summary.getCancelCount();
+  }
+
+  // =================== 내부 계산 ===================
+
+  /**
+   * 정산 금액 계산
+   * 순 판매 = 총 판매 - 환불
+   * 수수료 = 순 판매 × 20%
+   * 정산 예정 = 순 판매 - 수수료
+   * null 인 경우 0 으로 처리
+   */
+  private static long[] calculate(SettlementSummary summary) {
+    long total  = summary.getTotalAmount() == null ? 0L : summary.getTotalAmount();
+    long refund = summary.getRefundAmount() == null ? 0L : summary.getRefundAmount();
+    long net    = total - refund;
+    long comm   = (long) (net * 0.2);
+    long settle = net - comm;
+
+    return new long[]{total, refund, net, comm, settle};
+  }
+
+  // =================== 상태 판별 ===================
+
+  /**
+   * PENDING 상태 여부 확인
+   * 정산 갱신 가능 여부 판단에 사용
+   */
+  public boolean isPending() {
+    return this.settlementStatus == SettlementStatus.PENDING;
+  }
+}

--- a/src/main/java/com/example/assignment/domain/repository/SettlementRepository.java
+++ b/src/main/java/com/example/assignment/domain/repository/SettlementRepository.java
@@ -1,0 +1,13 @@
+package com.example.assignment.domain.repository;
+
+import com.example.assignment.domain.entity.Settlement;
+import com.example.assignment.domain.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+
+  Optional<Settlement> findByUserAndSettlementMonth(User user, String settlementMonth);
+}

--- a/src/main/java/com/example/assignment/domain/repository/querydsl/CourseQuery.java
+++ b/src/main/java/com/example/assignment/domain/repository/querydsl/CourseQuery.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class CourseQueryRepository {
+public class CourseQuery {
 
   private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/com/example/assignment/domain/repository/querydsl/SaleRecordQuery.java
+++ b/src/main/java/com/example/assignment/domain/repository/querydsl/SaleRecordQuery.java
@@ -1,0 +1,40 @@
+package com.example.assignment.domain.repository.querydsl;
+
+import com.example.assignment.domain.dto.response.SettlementSummary;
+import com.example.assignment.domain.entity.QSaleRecord;
+import com.example.assignment.domain.entity.User;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SaleRecordQuery {
+
+  private final JPAQueryFactory queryFactory;
+
+  /**
+   * 크리에이터별 월별 정산 집계 조회
+   * 판매 건수, 취소 건수, 총 판매 금액, 환불 금액을 집계하여 SettlementRes 로 반환
+   */
+  public SettlementSummary getSummary(User user, LocalDateTime start, LocalDateTime end) {
+    QSaleRecord saleRecord = QSaleRecord.saleRecord;
+
+    return queryFactory
+        .select(Projections.constructor(SettlementSummary.class,
+            saleRecord.amount.sum(),
+            saleRecord.refundAmount.sum(),
+            saleRecord.count(),
+            saleRecord.refundAmount.count()
+        ))
+        .from(saleRecord)
+        .where(
+            saleRecord.user.eq(user),
+            saleRecord.createdAt.between(start, end)
+        )
+        .fetchOne();
+  }
+
+}

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -38,6 +38,10 @@ public enum FailedType {
 
   // =================== 전역 예외 ===================
   INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "올바르지 않은 입력값입니다."),
+
+  // =================== 정산 ===================
+  INVALID_YEAR_MONTH(HttpStatus.BAD_REQUEST, "오늘 또는 이전 날짜를 선택해주세요."),
+  INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 형식이 올바르지 않습니다. (예: 2026-01)"),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/domain/type/SettlementStatus.java
+++ b/src/main/java/com/example/assignment/domain/type/SettlementStatus.java
@@ -1,0 +1,16 @@
+package com.example.assignment.domain.type;
+
+import lombok.Getter;
+
+@Getter
+public enum SettlementStatus {
+  PENDING("정산 대기"),
+  CONFIRMED("정산 확정"),
+  PAID("정산 완료");
+
+  private final String value;
+
+  SettlementStatus(String value) {
+    this.value = value;
+  }
+}

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -23,6 +23,9 @@ public enum SuccessType {
 
   // =================== 결제 ===================
   SUCCESS_PAYMENT(HttpStatus.OK, "결제가 완료되었습니다."),
+
+  // =================== 정산 ===================
+  SUCCESS_GET_SETTLEMENT(HttpStatus.OK, "정산 내역 조회에 성공했습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/service/CreatorService.java
+++ b/src/main/java/com/example/assignment/service/CreatorService.java
@@ -1,0 +1,8 @@
+package com.example.assignment.service;
+
+import com.example.assignment.domain.dto.ResultResponse;
+
+public interface CreatorService {
+
+  ResultResponse getSaleRecord(Long userId, String yearMonth);
+}

--- a/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CourseServiceImpl.java
@@ -14,7 +14,7 @@ import com.example.assignment.domain.entity.User;
 import com.example.assignment.domain.repository.CourseRepository;
 import com.example.assignment.domain.repository.EnrollmentRepository;
 import com.example.assignment.domain.repository.UserRepository;
-import com.example.assignment.domain.repository.querydsl.CourseQueryRepository;
+import com.example.assignment.domain.repository.querydsl.CourseQuery;
 import com.example.assignment.domain.type.CourseStatus;
 import com.example.assignment.domain.type.FailedType;
 import com.example.assignment.domain.type.SuccessType;
@@ -31,7 +31,7 @@ public class CourseServiceImpl implements CourseService {
 
   private final UserRepository userRepository;
   private final CourseRepository courseRepository;
-  private final CourseQueryRepository courseQueryRepository;
+  private final CourseQuery courseQuery;
   private final EnrollmentRepository enrollmentRepository;
 
   /**
@@ -64,7 +64,7 @@ public class CourseServiceImpl implements CourseService {
   @Transactional(readOnly = true)
   public ResultResponse getCourses(CourseSearchReq searchReq, int page) {
 
-    List<Course> courses = courseQueryRepository.searchCourses(searchReq);
+    List<Course> courses = courseQuery.searchCourses(searchReq);
 
     PageResponse<CoursePageRes> response = CoursePageRes.toList(courses, page);
 
@@ -187,6 +187,6 @@ public class CourseServiceImpl implements CourseService {
    * 동일 강사가 모든 필드가 같은 강의를 등록하는 경우 중복으로 판단
    */
   private boolean isDuplicateCourse(User user, CourseReq courseReq) {
-    return courseQueryRepository.existsDuplicateCourse(user, courseReq);
+    return courseQuery.existsDuplicateCourse(user, courseReq);
   }
 }

--- a/src/main/java/com/example/assignment/service/impl/CreatorServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/CreatorServiceImpl.java
@@ -1,0 +1,108 @@
+package com.example.assignment.service.impl;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import com.example.assignment.domain.dto.response.SettlementRes;
+import com.example.assignment.domain.dto.response.SettlementSummary;
+import com.example.assignment.domain.entity.Settlement;
+import com.example.assignment.domain.entity.User;
+import com.example.assignment.domain.repository.SettlementRepository;
+import com.example.assignment.domain.repository.UserRepository;
+import com.example.assignment.domain.repository.querydsl.SaleRecordQuery;
+import com.example.assignment.domain.type.FailedType;
+import com.example.assignment.domain.type.SuccessType;
+import com.example.assignment.exception.GlobalException;
+import com.example.assignment.service.CreatorService;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreatorServiceImpl implements CreatorService {
+
+  private final UserRepository userRepository;
+  private final SettlementRepository settlementRepository;
+  private final SaleRecordQuery saleRecordQuery;
+
+  /**
+   * 크리에이터 월별 정산 조회
+   * 이미 저장된 정산 데이터가 있으면 반환, 없으면 집계 후 저장
+   * PENDING 상태인 경우 취소 발생 여부를 반영하기 위해 재집계
+   */
+  @Override
+  @Transactional
+  public ResultResponse getSaleRecord(Long userId, String yearMonth) {
+
+    User user = getUser(userId);
+
+    if (user.isStudent()) {
+      throw new GlobalException(FailedType.ACCESS_DENIED);
+    }
+
+    Settlement settlement = getSettlement(user, yearMonth);
+    SettlementRes response = SettlementRes.toResponse(settlement);
+
+    return new ResultResponse(SuccessType.SUCCESS_GET_SETTLEMENT, response);
+  }
+
+  // =================== 내부 메서드 ===================
+
+  /**
+   * 유저 조회
+   * userId 에 해당하는 유저가 없으면 예외 발생
+   */
+  private User getUser(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+  }
+
+  /**
+   * 정산 데이터 조회
+   * 1. 저장된 정산 데이터가 있는 경우
+   *    - PENDING 상태: 취소 발생 가능성이 있으므로 재집계 후 업데이트
+   *    - CONFIRMED / PAID 상태: 확정된 금액이므로 그대로 반환
+   * 2. 저장된 정산 데이터가 없는 경우
+   *    - 집계 쿼리 실행 후 PENDING 상태로 저장
+   */
+  private Settlement getSettlement(User user, String yearMonth) {
+    YearMonth ym = getYearMonth(yearMonth);
+    LocalDateTime startAt = ym.atDay(1).atStartOfDay();
+    LocalDateTime endAt = ym.atEndOfMonth().atTime(23, 59, 59);
+
+    return settlementRepository
+        .findByUserAndSettlementMonth(user, ym.toString())
+        .map(s -> {
+          if (s.isPending()) {
+            SettlementSummary summary = saleRecordQuery.getSummary(user, startAt, endAt);
+            s.update(summary);
+          }
+          return s;
+        })
+        .orElseGet(() -> {
+          SettlementSummary summary = saleRecordQuery.getSummary(user, startAt, endAt);
+          Settlement settlement = Settlement.toEntity(user, ym, summary);
+          return settlementRepository.save(settlement);
+        });
+  }
+
+  /**
+   * 연월 파싱 및 검증
+   * - null 이면 현재 연월 사용
+   * - 미래 날짜면 예외 발생
+   * - 형식이 올바르지 않으면 예외 발생 (올바른 형식: 2025-03)
+   */
+  private YearMonth getYearMonth(String yearMonth) {
+    try {
+      YearMonth ym = (yearMonth == null) ? YearMonth.now() : YearMonth.parse(yearMonth);
+      if (ym.isAfter(YearMonth.now())) {
+        throw new GlobalException(FailedType.INVALID_YEAR_MONTH);
+      }
+      return ym;
+    } catch (DateTimeParseException e) {
+      throw new GlobalException(FailedType.INVALID_DATE_FORMAT);
+    }
+  }
+}


### PR DESCRIPTION
## 작업 내용
> 크리에이터가 월별 정산 집계 내역을 조회할 수 있는 API 구현
> 조회 시 정산 데이터를 Settlement 테이블에 저장하여 중복 집계를 방지하고,
> PENDING 상태인 경우 취소 발생 여부를 반영하기 위해 재집계 처리

## 주요 변경사항

### SettlementStatus 추가
```java
PENDING("정산 대기"), CONFIRMED("정산 확정"), PAID("정산 완료")
```

### Settlement 엔티티 구현
- `toEntity()` : 집계 데이터를 기반으로 정산 금액 계산 후 PENDING 상태로 생성
- `update()` : PENDING 상태일 때 최신 집계 데이터로 갱신
- `isPending()` : 정산 갱신 가능 여부 판별
- `calculate()` : 순 판매 / 수수료 / 정산 예정 금액 계산 내부 메서드

### SaleRecord 엔티티 변경
- 크리에이터 직접 참조 추가 (`User creator`)
- `toEntity()` 수정 : 강의 등록자를 크리에이터로 저장

### SaleRecordQuery 구현
- `getSummary()` : 크리에이터별 월별 판매/환불 집계 (QueryDSL)

### CreatorServiceImpl 구현
저장된 정산 데이터 유무와 상태에 따라 분기 처리.
```
정산 데이터 있음
├── PENDING     → 재집계 후 업데이트
└── CONFIRMED / PAID → 그대로 반환
정산 데이터 없음
└── 집계 후 PENDING 상태로 저장
```

### 연월 파싱 및 검증
- `null` 이면 현재 연월 사용
- 미래 날짜 입력 시 예외 발생
- 형식이 올바르지 않으면 예외 발생 (올바른 형식: `2025-03`)

### CourseQueryRepository → CourseQuery 클래스명 변경