### PR TITLE
[Feat] 과제 B - 운영자 정산 내역 집계 API 구현

### DIFF
--- a/src/main/java/com/example/assignment/controller/AdminController.java
+++ b/src/main/java/com/example/assignment/controller/AdminController.java
@@ -1,0 +1,35 @@
+package com.example.assignment.controller;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import com.example.assignment.service.AdminService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "운영자 전용 API", description = "정산 내역 집계")
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+  private final AdminService adminService;
+
+  @GetMapping("/{userId}/settlement")
+  public ResponseEntity<ResultResponse> getAdminSettlement(
+      @PathVariable Long userId,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startAt,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endAt,
+      @RequestParam(defaultValue = "1") int page) {
+
+    ResultResponse response = adminService.getSaleRecord(userId, startAt, endAt, page);
+    return new ResponseEntity<>(response, response.getStatus());
+  }
+
+}

--- a/src/main/java/com/example/assignment/domain/dto/response/AdminSettlementPageRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/AdminSettlementPageRes.java
@@ -1,0 +1,37 @@
+package com.example.assignment.domain.dto.response;
+
+import com.example.assignment.domain.dto.PageResponse;
+import java.text.NumberFormat;
+import java.util.List;
+import java.util.Locale;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminSettlementPageRes {
+
+  private static final NumberFormat FORMAT = NumberFormat.getInstance(Locale.KOREA);
+
+  private String totalAmount;
+  private String totalCommission;
+  private String totalSettlementAmount;
+  private PageResponse<AdminSettlementRes> pageResponse;
+
+  public static AdminSettlementPageRes toResponse(List<AdminSettlementRes> settlements, int page) {
+    long totalAmount      = settlements.stream().mapToLong(AdminSettlementRes::getRawTotalAmount).sum();
+    long totalCommission  = settlements.stream().mapToLong(AdminSettlementRes::getRawCommission).sum();
+    long totalSettlement  = settlements.stream().mapToLong(AdminSettlementRes::getRawSettlementAmount).sum();
+
+    return AdminSettlementPageRes.builder()
+        .totalAmount(FORMAT.format(totalAmount) + "원")
+        .totalCommission(FORMAT.format(totalCommission) + "원")
+        .totalSettlementAmount(FORMAT.format(totalSettlement) + "원")
+        .pageResponse(PageResponse.pagination(settlements, page))
+        .build();
+  }
+}

--- a/src/main/java/com/example/assignment/domain/dto/response/AdminSettlementRes.java
+++ b/src/main/java/com/example/assignment/domain/dto/response/AdminSettlementRes.java
@@ -1,0 +1,42 @@
+package com.example.assignment.domain.dto.response;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminSettlementRes {
+
+  private static final NumberFormat FORMAT = NumberFormat.getInstance(Locale.KOREA);
+
+  private Long creatorId;
+  private String creatorName;
+  private String totalAmount;
+  private String commission;
+  private String settlementAmount;
+
+  // 합계 계산용 원본 값
+  private Long rawTotalAmount;
+  private Long rawCommission;
+  private Long rawSettlementAmount;
+
+  public AdminSettlementRes(Long creatorId, String creatorName,
+      Long totalAmount, Long refundAmount) {
+    long total  = totalAmount == null ? 0L : totalAmount;
+    long refund = refundAmount == null ? 0L : refundAmount;
+    long net    = total - refund;
+    long comm   = (long) (net * 0.2);
+    long settle = net - comm;
+
+    this.creatorId           = creatorId;
+    this.creatorName         = creatorName;
+    this.rawTotalAmount      = net;
+    this.rawCommission       = comm;
+    this.rawSettlementAmount = settle;
+    this.totalAmount         = FORMAT.format(net) + "원";
+    this.commission          = FORMAT.format(comm) + "원";
+    this.settlementAmount    = FORMAT.format(settle) + "원";
+  }
+}

--- a/src/main/java/com/example/assignment/domain/entity/User.java
+++ b/src/main/java/com/example/assignment/domain/entity/User.java
@@ -35,4 +35,8 @@ public class User {
   public boolean isCreator() {
     return userRole == UserRole.CREATORS;
   }
+
+  public boolean isAdmin() {
+    return userRole == UserRole.ADMIN;
+  }
 }

--- a/src/main/java/com/example/assignment/domain/repository/querydsl/SaleRecordQuery.java
+++ b/src/main/java/com/example/assignment/domain/repository/querydsl/SaleRecordQuery.java
@@ -1,11 +1,14 @@
 package com.example.assignment.domain.repository.querydsl;
 
+import com.example.assignment.domain.dto.response.AdminSettlementRes;
 import com.example.assignment.domain.dto.response.SettlementSummary;
 import com.example.assignment.domain.entity.QSaleRecord;
 import com.example.assignment.domain.entity.User;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -35,6 +38,30 @@ public class SaleRecordQuery {
             saleRecord.createdAt.between(start, end)
         )
         .fetchOne();
+  }
+
+
+  public List<AdminSettlementRes> getAdminSettlement(LocalDate startAt, LocalDate endAt) {
+    QSaleRecord saleRecord = QSaleRecord.saleRecord;
+
+    LocalDateTime start = startAt.atStartOfDay();
+    LocalDateTime end = endAt.atTime(23, 59, 59);
+
+    return queryFactory
+        .select(Projections.constructor(AdminSettlementRes.class,
+            saleRecord.user.userId,
+            saleRecord.user.name,
+            saleRecord.amount.sum(),
+            saleRecord.refundAmount.sum()
+        ))
+        .from(saleRecord)
+        .join(saleRecord.user)
+        .where(
+            saleRecord.createdAt.between(start, end)
+        )
+        .groupBy(saleRecord.user.userId, saleRecord.user.name)
+        .orderBy(saleRecord.user.userId.asc())
+        .fetch();
   }
 
 }

--- a/src/main/java/com/example/assignment/domain/type/FailedType.java
+++ b/src/main/java/com/example/assignment/domain/type/FailedType.java
@@ -42,6 +42,7 @@ public enum FailedType {
   // =================== 정산 ===================
   INVALID_YEAR_MONTH(HttpStatus.BAD_REQUEST, "오늘 또는 이전 날짜를 선택해주세요."),
   INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 형식이 올바르지 않습니다. (예: 2026-01)"),
+  INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작일은 종료일보다 늦을 수 없습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/domain/type/SuccessType.java
+++ b/src/main/java/com/example/assignment/domain/type/SuccessType.java
@@ -26,6 +26,7 @@ public enum SuccessType {
 
   // =================== 정산 ===================
   SUCCESS_GET_SETTLEMENT(HttpStatus.OK, "정산 내역 조회에 성공했습니다."),
+  SUCCESS_GET_ADMIN_SETTLEMENT(HttpStatus.OK, "정산 집계 내역 조회에 성공했습니다."),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/assignment/domain/type/UserRole.java
+++ b/src/main/java/com/example/assignment/domain/type/UserRole.java
@@ -2,6 +2,6 @@ package com.example.assignment.domain.type;
 
 public enum UserRole {
 
-  CREATORS, STUDENT
+  ADMIN, CREATORS, STUDENT
 
 }

--- a/src/main/java/com/example/assignment/service/AdminService.java
+++ b/src/main/java/com/example/assignment/service/AdminService.java
@@ -1,0 +1,9 @@
+package com.example.assignment.service;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import java.time.LocalDate;
+
+public interface AdminService {
+
+  ResultResponse getSaleRecord(Long userId, LocalDate startAt, LocalDate endAt, int page);
+}

--- a/src/main/java/com/example/assignment/service/impl/AdminServiceImpl.java
+++ b/src/main/java/com/example/assignment/service/impl/AdminServiceImpl.java
@@ -1,0 +1,60 @@
+package com.example.assignment.service.impl;
+
+import com.example.assignment.domain.dto.ResultResponse;
+import com.example.assignment.domain.dto.response.AdminSettlementPageRes;
+import com.example.assignment.domain.dto.response.AdminSettlementRes;
+import com.example.assignment.domain.entity.User;
+import com.example.assignment.domain.repository.UserRepository;
+import com.example.assignment.domain.repository.querydsl.SaleRecordQuery;
+import com.example.assignment.domain.type.FailedType;
+import com.example.assignment.domain.type.SuccessType;
+import com.example.assignment.exception.GlobalException;
+import com.example.assignment.service.AdminService;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminServiceImpl implements AdminService {
+
+  private final UserRepository userRepository;
+  private final SaleRecordQuery saleRecordQuery;
+
+  @Override
+  public ResultResponse getSaleRecord(Long userId, LocalDate startAt, LocalDate endAt, int page) {
+
+    User user = getUser(userId);
+
+    if(!user.isAdmin()) {
+      throw new GlobalException(FailedType.ACCESS_DENIED);
+    }
+
+    validateDate(startAt, endAt);
+    List<AdminSettlementRes> settlements = saleRecordQuery.getAdminSettlement(startAt, endAt);
+    AdminSettlementPageRes response = AdminSettlementPageRes.toResponse(settlements, page);
+
+    return new ResultResponse(SuccessType.SUCCESS_GET_ADMIN_SETTLEMENT, response);
+  }
+
+  private User getUser(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new GlobalException(FailedType.USER_NOT_FOUND));
+  }
+
+  /**
+   * 기간 유효성 검증
+   * - 시작일이 종료일보다 늦으면 예외 발생
+   * - 미래 날짜면 예외 발생
+   */
+  private void validateDate(LocalDate startAt, LocalDate endAt) {
+    if (startAt.isAfter(endAt)) {
+      throw new GlobalException(FailedType.INVALID_DATE_RANGE);
+    }
+    if (startAt.isAfter(LocalDate.now())) {
+      throw new GlobalException(FailedType.INVALID_YEAR_MONTH);
+    }
+  }
+
+}


### PR DESCRIPTION
## 작업 내용
> 운영자가 시작일 ~ 종료일을 입력하면 해당 기간 내 전체 크리에이터의 정산 집계 내역을 조회할 수 있는 API를 구현합니다.
> 크리에이터별 정산 예정 금액과 함께 전체 합계(총 판매 / 수수료 / 정산 예정)를 응답합니다.

## 주요 변경사항

### UserRole, User 엔티티
운영자 권한을 구분하기 위해 `ADMIN` 역할과 `isAdmin()` 메서드를 추가합니다.
```java
ADMIN, CREATORS, STUDENT
```

### SaleRecordQuery - `getAdminSettlement()` 추가
`SaleRecord`를 직접 집계하는 방식으로 구현했습니다.
Settlement 테이블은 크리에이터가 조회할 때 생성되는 구조라, 데이터가 없는 크리에이터가 있을 수 있어 운영자 집계는 `SaleRecord`를 직접 사용합니다.
```
기간 필터 (createdAt BETWEEN start AND end)
    ↓
크리에이터별 GROUP BY
    ↓
판매 금액 SUM / 환불 금액 SUM 집계
```

### 응답 DTO
- `AdminSettlementRes` : 크리에이터별 순 판매 / 수수료 / 정산 예정 금액
- `AdminSettlementPageRes` : 크리에이터별 목록 + 전체 합계 (페이징 포함)

전체 합계는 DB 집계 없이 크리에이터별 raw 값을 스트림으로 합산하여 계산합니다.

### 기간 유효성 검증
```
시작일 > 종료일 → INVALID_DATE_RANGE
시작일이 미래   → INVALID_YEAR_MONTH